### PR TITLE
Add support for variable files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.1 (unreleased)
 - Variable support:
-  - Support for `${component.}` variables
+  - Support for `${var.}` variables; use with `--var-file` command line option
+  - Support for `${component.}` variables to use component output values
 - Azure: Include `frontend_endpoint` in ignore list when `suppress_changes` is used
 
 ## 1.0.0 (2021-05-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 1.1 (unreleased)
 - Variable support:
-  - Support for `${var.}` variables; use with `--var-file` command line option
-  - Support for `${component.}` variables to use component output values
+  - `${var.}` to be used with the `--var-file` command line option
+  - `${component.}` to use component output values
+  - `${env.}` to include environment variables in the configuration file
 - Azure: Include `frontend_endpoint` in ignore list when `suppress_changes` is used
 
 ## 1.0.0 (2021-05-10)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
     - reference/components/structure.md
     - reference/components/aws.md
     - reference/components/azure.md
+  - reference/variables.md
   - reference/cli.md
   - reference/changelog.md
 - How-to:

--- a/docs/src/howto/security/encrypt.md
+++ b/docs/src/howto/security/encrypt.md
@@ -4,6 +4,7 @@ A MACH configuration typically contains secrets that are configured on the compo
 
 We recommend using [SOPS](https://github.com/mozilla/sops) to encrypt your MACH configuration files or a part of it.
 
+## Using SOPS
 #### Encrypting
 
 Encrypting your file can be done with the `sops --encrypt` command:
@@ -39,3 +40,18 @@ And you can then execute MACH composer with this decrypted file:
 ```bash
 $ mach apply -f main.yml.dec
 ```
+
+## Encrypted variables
+
+Just as you would encrypt your MACH configuration, it is also possible to use an encrypted variable file to be used in your configuration.
+
+For example, if you would run MACH with 
+
+```bash
+mach apply -f main.yml --var-file variables.yml
+``` 
+
+and `variables.yml` is encrpyted with SOPS, MACH will use [terraform-sops](https://github.com/carlpett/terraform-provider-sops) to make sure the encrypted variables are used in a secure manner.
+
+!!! info "Using variables"
+    More info on using variables and variable files in MACH.

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -33,6 +33,7 @@ mach apply --auto-approve -f main.yml
 - `--with-sp-login` If az login with service principal environment variables should be done.
 - `--auto-approve` Auto-approve the Terraform plan
 - `--file` or `-f TEXT` YAML file to apply. If not set apply all *.yml files.
+- `--var-file` YAML file with variables to be used in the configuration file.
 - `--site` or `-s TEXT` Site to apply. If not set apply all sites.
 - `--component` or `-c TEXT` Specific component to target.
 - `--output-path TEXT` Output path, defaults to `cwd`/deployments`.
@@ -81,6 +82,7 @@ mach generate -f main.yml
 **Options**
 
 - `--file` or `-f TEXT` YAML file to parse. If not set parse all *.yml files.
+- `--var-file` YAML file with variables to be used in the configuration file.
 - `--site` or `-s TEXT` Site to parse. If not set parse all sites.
 - `--output-path TEXT` Output path, defaults to `cwd`/deployments.
 - `--ignore-version` Skip MACH composer version check
@@ -96,6 +98,7 @@ mach plan -f main.yml
 **Options**
 
 - `--file` or `-f TEXT` YAML file to parse. If not set parse all *.yml files.
+- `--var-file` YAML file with variables to be used in the configuration file.
 - `--site` or `-s TEXT` Site to generate plan of. If not set generate plans for all sites.
 - `--component` or `-c TEXT` Specific component to target.
 - `--output-path TEXT` Output path, defaults to `cwd`/deployments.

--- a/docs/src/reference/index.md
+++ b/docs/src/reference/index.md
@@ -4,5 +4,6 @@ This section contains references to the details of:
 
 - [MACH configuration syntax](./syntax/index.md)
 - [MACH component structure](./components/structure.md)
+- [Using variables](./variables.md)
 - [MACH CLI usage](./cli.md)
 - [Changelog](./changelog.md)

--- a/docs/src/reference/variables.md
+++ b/docs/src/reference/variables.md
@@ -43,19 +43,15 @@ components: ${include(components.yml)}
 
 You can use this to refer to any [Terraform output](https://www.terraform.io/docs/language/values/outputs.html) that another component has defined.
 
-So for example if a component called "infra" has the following outputs:
+So for example if a component called "email" has the following outputs:
 
 ```terraform
 # outputs.tf
 
-output "sns_topic_arn" {
-    value = aws_sns_topic.main.arn
-}
-
-output "psql_server" {
+output "sqs_queue" {
     value = {
-        endpoint = aws_db_instance.main.endpoint
-        arn = aws_db_instance.main.arn
+      id = aws_sqs_queue.email_queue.id
+      arn = aws_sqs_queue.email_queue.arn
     }
 }
 ```
@@ -66,8 +62,7 @@ These can then be used in the configuration:
 components:
   - name: order-notifier
     variables:
-      sns_topic: ${component.infra.sns_topic_arn}
-      database_endpoint: ${component.psql_server.endpoint}
+      email_queue_id: ${component.email.sqs_queue.id}
 ```
 
 ## `var`
@@ -88,6 +83,16 @@ will use the `stripe_secret` value from the given variables file.
 
 !!! info ""
     These values can be nested, so it's possible to define a `${var.site1.stripe.secret_key}` with your `variables.yml` looking like:
+
+    ```yaml
+    ---
+    site1:
+      stripe:
+        secret_key: vRBNcBH2XuNvHwAoPdDnhs2XyeVMOT
+    site2:
+      stripe:
+        secret_key: 2hzctJCLjyMjUL07BNSh3Nyjt6r7aC
+    ```
 
 !!! tip "Note on encryption"
     You can [encrypt your `variables.yml` using SOPS](../howto/security/encrypt.md#encrypted-variables).

--- a/docs/src/reference/variables.md
+++ b/docs/src/reference/variables.md
@@ -6,6 +6,7 @@ The following types are supported;
 
 - [`${component.}`](#component) component output references
 - [`${var.}`](#var) variables file values
+- [`${env.}`](#env) environment variables value
 - [`${include.}`](#include) file includes
 
 ## Example
@@ -14,7 +15,7 @@ The following types are supported;
 mach_composer:
   version: 1.0.0
 global:
-  environment: test
+  environment: ${env.MACH_ENVIRONMENT}
   cloud: aws
 sites:
   - identifier: my-site
@@ -92,6 +93,18 @@ will use the `stripe_secret` value from the given variables file.
     You can [encrypt your `variables.yml` using SOPS](../howto/security/encrypt.md#encrypted-variables).
 
     When doing so, MACH won't render the variable files directly into your Terraform configuration but uses [terraform-sops](https://github.com/carlpett/terraform-provider-sops) to refer you the SOPS encrypted variables within the Terraform file.
+
+## `env`
+**Usage** `${env.<variable-name>}`
+
+Use environment variables in your MACH configuration:
+
+```bash
+export MACH_ENVIRONMENT=test
+mach apply
+```
+
+Will replace `${env.MACH_ENVIRONMENT}` in our [example](#example) with `test`.
 
 ## `include`
 **Usage** `${include(<filename>)}`

--- a/docs/src/reference/variables.md
+++ b/docs/src/reference/variables.md
@@ -1,0 +1,106 @@
+# Variables
+
+MACH composer support the usage of variables in a configuration file.
+
+The following types are supported;
+
+- [`${component.}`](#component) component output references
+- [`${var.}`](#var) variables file values
+- [`${include.}`](#include) file includes
+
+## Example
+
+```yaml
+mach_composer:
+  version: 1.0.0
+global:
+  environment: test
+  cloud: aws
+sites:
+  - identifier: my-site
+    aws:
+      account_id: 1234567890
+      region: eu-central-1
+    endpoints:
+      public: api.tst.mach-example.net
+    components:
+      - name: infra
+      - name: payment
+        variables:
+          sns_topic: ${components.infra.sns_topic_arn}
+        secrets:
+          stripe_secret_key: ${var.stripe_secret}
+components: ${include(components.yml)}
+```
+
+- `${components.infra.sns_topic_arn}` uses the `sns_topic_arn` Terraform output as a value for the payment component
+- `${var.stripe_secret}` reads the `stripe_secret` from a variables file
+- `${include(components.yml)}` includes `components.yml` and injects it in the configuration
+
+## `component`
+**Usage** `${component.<component-name>.<output-value>}`
+
+You can use this to refer to any [Terraform output](https://www.terraform.io/docs/language/values/outputs.html) that another component has defined.
+
+So for example if a component called "infra" has the following outputs:
+
+```terraform
+# outputs.tf
+
+output "sns_topic_arn" {
+    value = aws_sns_topic.main.arn
+}
+
+output "psql_server" {
+    value = {
+        endpoint = aws_db_instance.main.endpoint
+        arn = aws_db_instance.main.arn
+    }
+}
+```
+
+These can then be used in the configuration:
+
+```yaml
+components:
+  - name: order-notifier
+    variables:
+      sns_topic: ${component.infra.sns_topic_arn}
+      database_endpoint: ${component.psql_server.endpoint}
+```
+
+## `var`
+**Usage** `${var.<variable-key>}`
+
+This can be used for using values from a *variables file*. This variable file must be set by using the [`--var-file` CLI option](./cli.md#apply):
+
+```bash
+mach apply -f main.yml --var-file variables.yml
+```
+
+From the [example](#example) above, the following configuration line:
+```yaml
+stripe_secret_key: ${var.stripe_secret}
+```
+
+will use the `stripe_secret` value from the given variables file. 
+
+!!! info ""
+    These values can be nested, so it's possible to define a `${var.site1.stripe.secret_key}` with your `variables.yml` looking like:
+
+!!! tip "Note on encryption"
+    You can [encrypt your `variables.yml` using SOPS](../howto/security/encrypt.md#encrypted-variables).
+
+    When doing so, MACH won't render the variable files directly into your Terraform configuration but uses [terraform-sops](https://github.com/carlpett/terraform-provider-sops) to refer you the SOPS encrypted variables within the Terraform file.
+
+## `include`
+**Usage** `${include(<filename>)}`
+
+Any valid YAML file can be included here.
+
+!!! info "Using `!include`"
+    The `${include(...)}` syntax has the same effect as using `!include ...` in your YAML file.
+
+    However, when using [SOPS](../topics/../howto/security/encrypt.md) to encrypt your configuration file, this tag will get stripped.
+    Therefor, MACH also supports the MACH-specific syntax.
+

--- a/generate_schema.py
+++ b/generate_schema.py
@@ -7,6 +7,9 @@ schema = types.MachConfig.json_schema()
 del schema["properties"]["output_path"]
 del schema["properties"]["file"]
 del schema["properties"]["file_encrypted"]
+del schema["properties"]["variables"]
+del schema["properties"]["variables_path"]
+del schema["properties"]["variables_encrypted"]
 
 with open("schema.json", 'w') as f:
     f.write(json.dumps(schema, indent=2))

--- a/src/mach/bootstrap/config.py
+++ b/src/mach/bootstrap/config.py
@@ -166,6 +166,7 @@ def _clean_config_dump(data: dict) -> dict:
     data.pop("file_encrypted", None)
 
     data.pop("variables", None)
+    data.pop("variables_path", None)
     data.pop("variables_encrypted", None)
 
     return data

--- a/src/mach/bootstrap/config.py
+++ b/src/mach/bootstrap/config.py
@@ -161,6 +161,11 @@ def _clean_config_dump(data: dict) -> dict:
 
     TODO: These are actions that should be performed in the Marshmallow schema.
     """
-    del data["output_path"]
-    del data["file_encrypted"]
+    data.pop("output_path", None)
+    data.pop("file", None)
+    data.pop("file_encrypted", None)
+
+    data.pop("variables", None)
+    data.pop("variables_encrypted", None)
+
     return data

--- a/src/mach/commands.py
+++ b/src/mach/commands.py
@@ -62,7 +62,7 @@ def terraform_command(f):
     def new_func(
         file, site, output_path: str, ignore_version: bool, var_file, **kwargs
     ):
-        files = get_input_files(file)
+        files = get_input_files(file, var_file=var_file)
 
         configs = parse.parse_configs(
             files, output_path, ignore_version=ignore_version, var_file=var_file
@@ -319,7 +319,7 @@ def bootstrap(output: str, type_: str, cookiecutter: str):
         _bootstrap.create_component(output, cookiecutter)
 
 
-def get_input_files(file: Optional[str]) -> List[str]:
+def get_input_files(file: Optional[str], *, var_file: str) -> List[str]:
     """Determine input files. If file is not specified use all *.yml files."""
     if file:
         files = [file]
@@ -328,4 +328,13 @@ def get_input_files(file: Optional[str]) -> List[str]:
     if not files:
         click.echo("No .yml files found")
         sys.exit(1)
+
+    # If a var-file is given, strip it from the list of files to parse a MACH configurations.
+    # This is mainly a convenience for when you have the following files;
+    # - main.yml
+    # - variables.yml
+    # and to run `mach apply --var-file variables.yml`
+    # instead of `mach apply -f main.yml --var-file variables.yml`
+    if var_file:
+        files = filter(lambda f: f.lstrip("./") != var_file, files)
     return files

--- a/src/mach/commands.py
+++ b/src/mach/commands.py
@@ -55,10 +55,18 @@ def terraform_command(f):
         default="deployments",
         help="Output path, defaults to `cwd`/deployments.",
     )
-    def new_func(file, site, output_path: str, ignore_version: bool, **kwargs):
+    @click.option(
+        "--var-file",
+        help="Use a variable file to parse the configuration with",
+    )
+    def new_func(
+        file, site, output_path: str, ignore_version: bool, var_file, **kwargs
+    ):
         files = get_input_files(file)
 
-        configs = parse.parse_configs(files, output_path, ignore_version=ignore_version)
+        configs = parse.parse_configs(
+            files, output_path, ignore_version=ignore_version, var_file=var_file
+        )
         try:
             result = f(
                 file=file,

--- a/src/mach/templates/__init__.py
+++ b/src/mach/templates/__init__.py
@@ -68,6 +68,13 @@ def parse_config_variable(value: any):
                 "component-name.output-name"
             )
         return f"module.{parts[0]}.{parts[1]}"
+    if type_ == "var":
+        # This should not happen
+        raise MachError(
+            "${var...} variables should have been parsed already by MACH composer. "
+            "Something went wrong."
+        )
+
     return None
 
 

--- a/src/mach/templates/partials/amplience.tf
+++ b/src/mach/templates/partials/amplience.tf
@@ -1,7 +1,7 @@
 {% set amplience = site.amplience %}
 
 provider "amplience" {
-  client_id        = "{{ amplience.client_id }}"
-  client_secret    = "{{ amplience.client_secret }}"
-  hub_id           = "{{ amplience.hub_id }}"
+  client_id        = {{ amplience.client_id|tf }}
+  client_secret    = {{ amplience.client_secret|tf }}
+  hub_id           = {{ amplience.hub_id|tf }}
 }

--- a/src/mach/templates/partials/aws.tf
+++ b/src/mach/templates/partials/aws.tf
@@ -1,6 +1,6 @@
 {% set aws = site.aws %}
 provider "aws" {
-  region  = "{{ aws.region }}"
+  region  = {{ aws.region|tf }}
   {% if aws.deploy_role_name %}
   assume_role {
     role_arn = "arn:aws:iam::{{ aws.account_id }}:role/{{ aws.deploy_role_name }}"
@@ -10,8 +10,8 @@ provider "aws" {
 
 {% for provider in aws.extra_providers %}
 provider "aws" {
-  alias   = "{{ provider.name }}"
-  region  = "{{ provider.region }}"
+  alias   = {{ provider.name|tf }}
+  region  = {{ provider.region|tf }}
 
   {% if aws.deploy_role_name %}
   assume_role {
@@ -37,6 +37,6 @@ provider "aws" {
 locals {
   tags = {
     Site = "{{ site.identifier }}"
-    Environment = "{{ general_config.environment }}"
+    Environment = {{ general_config.environment|tf }}
   }
 }

--- a/src/mach/templates/partials/azure.tf
+++ b/src/mach/templates/partials/azure.tf
@@ -1,37 +1,37 @@
 {% set azure = site.azure %}
 
 provider "azurerm" {
-  subscription_id = "{{ azure.subscription_id }}"
-  tenant_id       = "{{ azure.tenant_id }}"
+  subscription_id = {{ azure.subscription_id|tf }}
+  tenant_id       = {{ azure.tenant_id|tf }}
   skip_provider_registration = true
   features {}
 }
 
 
 locals {
-  tenant_id                    = "{{ azure.tenant_id }}"
-  region                       = "{{ azure.region }}"
-  subscription_id              = "{{ azure.subscription_id }}"
-  project_key                  = "{{ site.commercetools.project_key }}"
+  tenant_id                    = {{ azure.tenant_id|tf }}
+  region                       = {{ azure.region|tf }}
+  subscription_id              = {{ azure.subscription_id|tf }}
+  project_key                  = {{ site.commercetools.project_key|tf }}
 
   region_short                 = "{{ azure.region|azure_region_short }}"
   name_prefix                  = format("{{ general_config.azure.resources_prefix }}{{ site.identifier| replace("dev", "d") | replace("tst", "t") | replace("prd", "p") }}-%s", local.region_short)
 
   service_object_ids           = {
       {% for key, value in azure.service_object_ids.items() %}
-          {{ key }} = "{{ value }}"
+          {{ key }} = {{ value|tf }}
       {% endfor %}
   }
 
   tags = {
     Site = "{{ site.identifier }}"
-    Environment = "{{ general_config.environment }}"
+    Environment = {{ general_config.environment|tf }}
   }
 }
 
 {% if azure.resource_group %}
 data "azurerm_resource_group" "main" {
-  name = "{{ azure.resource_group }}"
+  name = {{ azure.resource_group|tf }}
 }  
 {% else %}
 resource "azurerm_resource_group" "main" {
@@ -55,8 +55,8 @@ locals {
 {% if azure.alert_group %}
 {% if azure.alert_group.logic_app %}
 data "azurerm_logic_app_workflow" "alert_logic_app" {
-  name                = "{{ azure.alert_group.logic_app_name }}"
-  resource_group_name = "{{ azure.alert_group.logic_app_resource_group }}"
+  name                = {{ azure.alert_group.logic_app_name|tf }}
+  resource_group_name = {{ azure.alert_group.logic_app_resource_group|tf }}
 }
 {% endif %}
 
@@ -67,8 +67,8 @@ resource "azurerm_monitor_action_group" "alert_action_group" {
 
   {% for email in azure.alert_group.alert_emails %}
   email_receiver {
-    name          = "{{ email }}"
-    email_address = "{{ email }}"
+    name          = {{ email|tf }}
+    email_address = {{ email|tf }}
   }
   {% endfor %}
 
@@ -84,7 +84,7 @@ resource "azurerm_monitor_action_group" "alert_action_group" {
   {% if azure.alert_group.webhook_url %}
   webhook_receiver {
     name                    = "alert_webhook"
-    service_uri             = "{{ azure.alert_group.webhook_url }}"
+    service_uri             = {{ azure.alert_group.webhook_url|tf }}
     use_common_alert_schema = true
   }
   {% endif %}

--- a/src/mach/templates/partials/azure_app_service_plans.tf
+++ b/src/mach/templates/partials/azure_app_service_plans.tf
@@ -18,14 +18,14 @@ resource "azurerm_app_service_plan" "{{ key|service_plan_resource_name }}" {
   {% else %}local.resource_group_name
   {% endif %}
   location            = local.resource_group_location
-  kind                = "{{ plan.kind }}"
+  kind                = {{ plan.kind|tf }}
   reserved            = {% if plan.kind|lower == 'windows' %}false{% else %}true{% endif %}
 
   sku {
-    tier = "{{ plan.tier }}"
-    size = "{{ plan.size }}"
+    tier = {{ plan.tier|tf }}
+    size = {{ plan.size|tf }}
     {% if plan.capacity -%}
-    capacity = {{ plan.capacity }}
+    capacity = {{ plan.capacity|tf }}
     {% endif %}
   }
 

--- a/src/mach/templates/partials/commercetools.tf
+++ b/src/mach/templates/partials/commercetools.tf
@@ -1,20 +1,20 @@
 {% set commercetools = site.commercetools %}
 
 provider "commercetools" {
-    client_id     = "{{ commercetools.client_id }}"
-    client_secret = "{{ commercetools.client_secret }}"
-    project_key   = "{{ commercetools.project_key }}"
-    scopes        = "{{ commercetools.scopes }}"
-    token_url     = "{{ commercetools.token_url }}"
-    api_url       = "{{ commercetools.api_url }}"
+    client_id     = {{ commercetools.client_id|tf }}
+    client_secret = {{ commercetools.client_secret|tf }}
+    project_key   = {{ commercetools.project_key|tf }}
+    scopes        = {{ commercetools.scopes|tf }}
+    token_url     = {{ commercetools.token_url|tf }}
+    api_url       = {{ commercetools.api_url|tf }}
 }
 
 {% if commercetools.project_settings %}
 resource "commercetools_project_settings" "project" {
-    name       = "{{ commercetools.project_key }}"
-    countries  = [{% for country in commercetools.project_settings.countries %}"{{ country }}"{% if not loop.last %},{% endif %}{% endfor %}]
-    currencies = [{% for currency in commercetools.project_settings.currencies %}"{{ currency }}"{% if not loop.last %},{% endif %}{% endfor %}]
-    languages  = [{% for language in commercetools.project_settings.languages %}"{{ language }}"{% if not loop.last %},{% endif %}{% endfor %}]
+    name       = {{ commercetools.project_key|tf }}
+    countries  = [{% for country in commercetools.project_settings.countries %}{{ country|tf }}{% if not loop.last %},{% endif %}{% endfor %}]
+    currencies = [{% for currency in commercetools.project_settings.currencies %}{{ currency|tf }}{% if not loop.last %},{% endif %}{% endfor %}]
+    languages  = [{% for language in commercetools.project_settings.languages %}{{ language|tf }}{% if not loop.last %},{% endif %}{% endfor %}]
     messages   = {
         enabled = {{ commercetools.project_settings.messages_enabled | string | lower }}
     }
@@ -24,12 +24,12 @@ resource "commercetools_project_settings" "project" {
 {% for channel in commercetools.channels %}
 resource "commercetools_channel" "{{ channel.key }}" {
     key = "{{ channel.key }}"
-    roles = [{% for role in channel.roles %}"{{ role }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+    roles = [{% for role in channel.roles %}{{ role|tf }}{% if not loop.last %}, {% endif %}{% endfor %}]
 
     {% if channel.name %}
     name = {
         {% for language, localized_name in channel.name.items() %}
-        {{ language }} = "{{ localized_name }}"
+        {{ language }} = {{ localized_name|tf }}
         {% endfor %}
     }
     {% endif %}
@@ -37,7 +37,7 @@ resource "commercetools_channel" "{{ channel.key }}" {
     {% if channel.description %}
     description = {
         {% for language, localized_name in channel.description.items() %}
-        {{ language }} = "{{ localized_name}}"
+        {{ language }} = {{ localized_name|tf }}
         {% endfor %}
     }
     {% endif %}
@@ -53,8 +53,8 @@ resource "commercetools_tax_category" "standard" {
 {% for tax in commercetools.taxes %}
 resource "commercetools_tax_category_rate" "{{ tax.country|lower }}_vat" {
   tax_category_id = commercetools_tax_category.standard.id
-  name = "{{ tax.name }}"
-  amount = {{ tax.amount }}
+  name = {{ tax.name|tf }}
+  amount = {{ tax.amount|tf }}
   country = "{{ tax.country }}"
   included_in_price = true
 }
@@ -64,12 +64,12 @@ resource "commercetools_tax_category_rate" "{{ tax.country|lower }}_vat" {
 {% for zone in commercetools.zones %}
 resource "commercetools_shipping_zone" "{{ zone.name|slugify }}" {
   name = "{{ zone.name }}"
-  description = "{{ zone.description }}"
+  description = {{ zone.description|tf }}
   {% for location in zone.locations %}
   location {
-      country = "{{ location.country }}"
+      country = {{ location.country|tf }}
       {% if location.state %}
-      state = "{{ location.state }}"
+      state = {{ location.state|tf }}
       {% endif %}
   }
   {% endfor %}

--- a/src/mach/templates/partials/component.tf
+++ b/src/mach/templates/partials/component.tf
@@ -2,8 +2,8 @@
 
 {% if "sentry" in component.integrations and general_config.sentry.managed %}
 resource "sentry_key" "{{ component.name }}" {
-  organization = "{{ general_config.sentry.organization }}"
-  project = "{{ component.sentry.project }}"
+  organization = {{ general_config.sentry.organization|tf }}
+  project = {{ component.sentry.project|tf }}
   name = "{{ site.identifier }}_{{ component.name }}"
   {% if component.sentry.rate_limit_window %}
   rate_limit_window = {{ component.sentry.rate_limit_window }}
@@ -20,21 +20,21 @@ module "{{ component.name }}" {
   {% if component.has_cloud_integration or component.variables %}
   variables = {
     {% for key, value in component.variables.items() %}
-    {{ key }} = {{ value|variable_value }}
+    {{ key }} = {{ value|tfvalue }}
     {% endfor %}
   }
   {% endif %}
   {% if component.has_cloud_integration or component.secrets %}
   secrets = {
     {% for key, value in component.secrets.items() %}
-    {{ key }} = {{ value|variable_value }}
+    {{ key }} = {{ value|tfvalue }}
     {% endfor %}
   }
   {% endif %}
 
   {% if component.has_cloud_integration %}
-  component_version       = "{{ definition.version }}"
-  environment             = "{{ general_config.environment }}"
+  component_version       = {{ definition.version|tf }}
+  environment             = {{ general_config.environment|tf }}
   site                    = "{{ site.identifier }}"
   tags                    = local.tags
   {% endif %}
@@ -52,22 +52,22 @@ module "{{ component.name }}" {
   {% endif %}
 
   {% if "commercetools" in component.integrations %}
-    ct_project_key    = "{{ site.commercetools.project_key }}"
-    ct_api_url        = "{{ site.commercetools.api_url }}"
-    ct_auth_url       = "{{ site.commercetools.token_url }}"
+    ct_project_key    = {{ site.commercetools.project_key|tf }}
+    ct_api_url        = {{ site.commercetools.api_url|tf }}
+    ct_auth_url       = {{ site.commercetools.token_url|tf }}
 
     ct_stores = {
       {% for store in site.commercetools.stores %}
       {{ store.key }} =  {
-        key = "{{ store.key }}"
+        key = {{ store.key|tf }}
         variables = {
           {% for key, value in component.store_variables.get(store.key, {}).items() %}
-          {{ key }} = {{ value|variable_value }}
+          {{ key }} = {{ value|tfvalue }}
           {% endfor %}
         }
         secrets = {
           {% for key, value in component.store_secrets.get(store.key, {}).items() %}
-          {{ key }} = {{ value|variable_value }}
+          {{ key }} = {{ value|tfvalue }}
           {% endfor %}
         }
       }
@@ -81,16 +81,16 @@ module "{{ component.name }}" {
   {% endif %}
 
   {% if "amplience" in component.integrations %}
-    amplience_client_id = "{{ site.amplience.client_id }}"
-    amplience_client_secret = "{{ site.amplience.client_secret }}"
-    amplience_hub_id = "{{ site.amplience.hub_id }}"
+    amplience_client_id = {{ site.amplience.client_id|tf }}
+    amplience_client_secret = {{ site.amplience.client_secret|tf }}
+    amplience_hub_id = {{ site.amplience.hub_id|tf }}
   {% endif %}
 
   {% if "apollo_federation" in component.integrations %}
     apollo_federation = {
-      api_key       = "{{ site.apollo_federation.api_key }}"
-      graph         = "{{ site.apollo_federation.graph }}"
-      graph_variant = "{{ site.apollo_federation.graph_variant }}"
+      api_key       = {{ site.apollo_federation.api_key|tf }}
+      graph         = {{ site.apollo_federation.graph|tf }}
+      graph_variant = {{ site.apollo_federation.graph_variant|tf }}
     }
   {% endif %}
 

--- a/src/mach/templates/partials/contentful.tf
+++ b/src/mach/templates/partials/contentful.tf
@@ -1,13 +1,13 @@
 {% set contentful = site.contentful %}
 
 provider "contentful" {
-  cma_token       = "{{ contentful.cma_token }}"
-  organization_id = "{{ contentful.organization_id }}"
+  cma_token       = {{ contentful.cma_token|tf }}
+  organization_id = {{ contentful.organization_id|tf }}
 }
 
 resource "contentful_space" "space" {
-  name           = "{{ contentful.space }}"
-  default_locale = "{{ contentful.default_locale }}"
+  name           = {{ contentful.space|tf }}
+  default_locale = {{ contentful.default_locale|tf }}
 }
 
 resource "contentful_apikey" "apikey" {

--- a/src/mach/templates/partials/endpoints/aws_api_gateway.tf
+++ b/src/mach/templates/partials/endpoints/aws_api_gateway.tf
@@ -34,7 +34,7 @@ resource "aws_apigatewayv2_stage" "{{ endpoint.key|slugify }}_default" {
 
 {% if endpoint.url %}
 resource "aws_acm_certificate" "{{ endpoint.key|slugify }}" {
-  domain_name       = "{{ endpoint.url }}"
+  domain_name       = {{ endpoint.url|tf }}
   validation_method = "DNS"
 }
 
@@ -57,7 +57,7 @@ resource "aws_route53_record" "{{ endpoint.key|slugify }}_acm_validation" {
 
 # Route53 mappings
 resource "aws_apigatewayv2_domain_name" "{{ endpoint.key|slugify }}" {
-  domain_name = "{{ endpoint.url }}"
+  domain_name = {{ endpoint.url|tf }}
 
   domain_name_configuration {
     certificate_arn = aws_acm_certificate.{{ endpoint.key|slugify }}.arn
@@ -81,6 +81,6 @@ resource "aws_route53_record" "{{ endpoint.key|slugify }}" {
 resource "aws_apigatewayv2_api_mapping" "{{ endpoint.key|slugify }}" {
   api_id      = aws_apigatewayv2_api.{{ endpoint.key|slugify }}_gateway.id
   stage       = aws_apigatewayv2_stage.{{ endpoint.key|slugify }}_default.id
-  domain_name = "{{ endpoint.url }}"
+  domain_name = {{ endpoint.url|tf }}
 }
 {% endif %}

--- a/src/mach/templates/partials/endpoints/aws_url_locals.tf
+++ b/src/mach/templates/partials/endpoints/aws_url_locals.tf
@@ -1,6 +1,6 @@
 locals {
 {% for endpoint in site.used_endpoints %}
-  endpoint_url_{{ endpoint.key|slugify }} = {% if endpoint.url %}"{{ endpoint.url }}"{% else %}aws_apigatewayv2_api.{{ endpoint.key|slugify }}_gateway.api_endpoint{% endif %}
+  endpoint_url_{{ endpoint.key|slugify }} = {% if endpoint.url %}{{ endpoint.url|tf }}{% else %}aws_apigatewayv2_api.{{ endpoint.key|slugify }}_gateway.api_endpoint{% endif %}
 
 {% endfor %}
 }

--- a/src/mach/templates/partials/endpoints/azure_frontdoor.tf
+++ b/src/mach/templates/partials/endpoints/azure_frontdoor.tf
@@ -5,14 +5,14 @@ locals {
 
 {% for endpoint in site.used_custom_endpoints %}
 data "azurerm_dns_zone" "{{ endpoint.key }}" {
-    name                = "{{ endpoint.zone }}"
-    resource_group_name = "{{ site.azure.frontdoor.dns_resource_group }}"
+    name                = {{ endpoint.zone|tf }}
+    resource_group_name = {{ site.azure.frontdoor.dns_resource_group|tf }}
 }
 
 resource "azurerm_dns_cname_record" "{{ endpoint.key }}" {
-  name                = "{{ endpoint.subdomain }}"
+  name                = {{ endpoint.subdomain|tf }}
   zone_name           = data.azurerm_dns_zone.{{ endpoint.key }}.name
-  resource_group_name = "{{ site.azure.frontdoor.dns_resource_group }}"
+  resource_group_name = {{ site.azure.frontdoor.dns_resource_group|tf }}
   ttl                 = 600
   record              = local.frontdoor_domain
 }
@@ -36,8 +36,8 @@ resource "azurerm_frontdoor" "app-service" {
 
   {% for endpoint in site.used_custom_endpoints %}
   frontend_endpoint {
-    name                              = "{{ endpoint.key }}"
-    host_name                         = "{{ endpoint.url }}"
+    name                              = {{ endpoint.key|tf }}
+    host_name                         = {{ endpoint.url|tf }}
 
     custom_https_provisioning_enabled = true
     custom_https_configuration {
@@ -59,7 +59,7 @@ resource "azurerm_frontdoor" "app-service" {
     frontend_endpoints = [
       local.frontdoor_domain_identifier,
       {% for endpoint in site.used_custom_endpoints %}
-      "{{ endpoint.key }}",
+      {{ endpoint.key|tf }},
       {% endfor %}
     ]
     redirect_configuration {
@@ -85,7 +85,7 @@ resource "azurerm_frontdoor" "app-service" {
     frontend_endpoints = [
       local.frontdoor_domain_identifier,
       {% if endpoint.url %}
-      "{{ endpoint.key }}",
+      {{ endpoint.key|tf }},
       {% endif %}
     ]
     forwarding_configuration {

--- a/src/mach/templates/partials/endpoints/azure_url_locals.tf
+++ b/src/mach/templates/partials/endpoints/azure_url_locals.tf
@@ -1,6 +1,6 @@
 locals {
 {% for endpoint in site.used_endpoints %}
-endpoint_url_{{ endpoint.key|slugify }} = {% if endpoint.url %}"{{ endpoint.url }}"{% else %}local.frontdoor_domain{% endif %}
+endpoint_url_{{ endpoint.key|slugify }} = {% if endpoint.url %}{{ endpoint.url|tf }}{% else %}local.frontdoor_domain{% endif %}
 
 {% endfor %}
 }

--- a/src/mach/terraform.py
+++ b/src/mach/terraform.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -29,6 +30,11 @@ def generate_terraform(config: MachConfig, *, site: str = None):
         with open(output_file, "w+") as fh:
             fh.write(content)
         click.echo(f"Generated file {output_file}")
+
+        if config.variables_path and config.variables_encrypted:
+            # We need to copy the variables file for Terraform to access it
+            shutil.copy(config.variables_path, f"{site_dir}/variables.yml")
+            click.echo("Copied variables file")
 
         run_terraform("fmt", cwd=site_dir)
 

--- a/src/mach/types/__init__.py
+++ b/src/mach/types/__init__.py
@@ -4,3 +4,4 @@ from .general_config import *  # NOQA
 from .mach import *  # NOQA
 from .shared import *  # NOQA
 from .sites import *  # NOQA
+from .values import *  # NOQA

--- a/src/mach/types/base.py
+++ b/src/mach/types/base.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from dataclasses_json import config, dataclass_json
 from dataclasses_jsonschema import JsonSchemaMixin
@@ -30,7 +30,7 @@ class MachConfig(JsonSchemaMixin):
     # Indicates that the config file is SOPS encrypted
     file_encrypted: bool = False
 
-    variables: dict = fields.dict_()
+    variables: Dict[str, Any] = fields.dict_()
     variables_path: str = fields.none()
     variables_encrypted: bool = False
 

--- a/src/mach/types/base.py
+++ b/src/mach/types/base.py
@@ -29,6 +29,8 @@ class MachConfig(JsonSchemaMixin):
     file: Optional[str] = fields.none()
     # Indicates that the config file is SOPS encrypted
     file_encrypted: bool = False
+    variables: dict = fields.dict_()
+    variables_encrypted: bool = False
 
     @property
     def deployment_path(self) -> Path:

--- a/src/mach/types/base.py
+++ b/src/mach/types/base.py
@@ -29,7 +29,9 @@ class MachConfig(JsonSchemaMixin):
     file: Optional[str] = fields.none()
     # Indicates that the config file is SOPS encrypted
     file_encrypted: bool = False
+
     variables: dict = fields.dict_()
+    variables_path: str = fields.none()
     variables_encrypted: bool = False
 
     @property

--- a/src/mach/types/values.py
+++ b/src/mach/types/values.py
@@ -1,0 +1,3 @@
+class TerraformReference(str):
+    # Indicating that this value must be parsed as a Terraform reference, not a string
+    pass

--- a/src/mach/variables.py
+++ b/src/mach/variables.py
@@ -1,0 +1,22 @@
+from mach.exceptions import MachError
+
+
+class VariableNotFound(MachError):
+    def __init__(self, var_name: str):
+        super().__init__(f"Variable {var_name} not found in variables")
+
+
+def resolve_variable(var, variables):
+    lookup, *remain = var.split(".", maxsplit=1)
+
+    try:
+        value = variables[lookup]
+    except KeyError:
+        raise VariableNotFound(var)
+
+    if remain:
+        try:
+            return resolve_variable(remain[0], value)
+        except VariableNotFound:
+            raise VariableNotFound(var)
+    return value

--- a/src/mach/yaml.py
+++ b/src/mach/yaml.py
@@ -12,11 +12,14 @@ import requests
 import yaml
 import yamlinclude
 from mach import exceptions, git
+from yaml.error import YAMLError  # noqa
 
 EXTERNAL_RE = re.compile(r"^(git::)?(http|https)://")
 INCLUDE_RE = re.compile(r"^(.*)\${include\((.*)\)}\s*$")
 
 Encrypted = bool
+
+__all__ = ["YAMLError", "load"]
 
 
 class YamlFileIO(io.TextIOWrapper):

--- a/tests/unittests/test_parse.py
+++ b/tests/unittests/test_parse.py
@@ -71,6 +71,16 @@ def test_parse_azure_service_plans(azure_config: types.MachConfig):
     )
 
 
+def test_parse_w_variables(config: types.MachConfig):
+    config.sites[0].components[0].variables = {"my-value": r"${var.my-value}"}
+    with pytest.raises(Exception):
+        config = parse.parse_config(config)
+
+    config.variables["my-value"] = "foo"
+    config = parse.parse_config(config)
+    assert config.sites[0].components[0].variables == {"my-value": "foo"}
+
+
 @pytest.mark.parametrize("filename", ["aws_config1.yml", "aws_config_external.yml"])
 def test_parse_from_file(filename):
     config = parse.parse_config_from_file(get_file(filename))

--- a/tests/unittests/test_templates.py
+++ b/tests/unittests/test_templates.py
@@ -15,18 +15,18 @@ def test_zone_name_filter(url, zone):
     assert templates.zone_name(url) == zone
 
 
-def test_render_variable():
-    assert templates.render_variable(True) == "true"
-    assert templates.render_variable(False) == "false"
+def test_render_tfvalue():
+    assert templates.render_tfvalue(True) == "true"
+    assert templates.render_tfvalue(False) == "false"
 
-    assert templates.render_variable(12) == 12
+    assert templates.render_tfvalue(12) == 12
     assert (
-        templates.render_variable(["value1", False, "value2"])
+        templates.render_tfvalue(["value1", False, "value2"])
         == """["value1",false,"value2"]"""
     )
 
     assert (
-        templates.render_variable(r"${component.infra.db_password}")
+        templates.render_tfvalue(r"${component.infra.db_password}")
         == "module.infra.db_password"
     )
 

--- a/tests/unittests/test_variables.py
+++ b/tests/unittests/test_variables.py
@@ -1,0 +1,14 @@
+import pytest
+from mach import variables
+
+
+def test_resolve_variables():
+    vars = {"my-value": "foo", "secrets": {"site1": {"my-value": "bar"}}}
+
+    variables.resolve_variable("my-value", vars) == "foo"
+    with pytest.raises(variables.VariableNotFound):
+        variables.resolve_variable("my-other-value", vars)
+
+    variables.resolve_variable("secrets.site1.my-value", vars) == "bar"
+    with pytest.raises(variables.VariableNotFound):
+        variables.resolve_variable("secrets.site2.my-value", vars)


### PR DESCRIPTION
MACH composer support the usage of variables in a configuration file.

The following types are supported;

- [`${component.}`](#component) component output references
- [`${var.}`](#var) variables file values
- [`${env.}`](#env) environment variables value
- [`${include.}`](#include) file includes

## Example

```yaml
mach_composer:
  version: 1.0.0
global:
  environment: test
  cloud: aws
sites:
  - identifier: my-site
    aws:
      account_id: 1234567890
      region: eu-central-1
    endpoints:
      public: api.tst.mach-example.net
    components:
      - name: infra
      - name: payment
        variables:
          sns_topic: ${components.infra.sns_topic_arn}
        secrets:
          stripe_secret_key: ${var.stripe_secret}
components: ${include(components.yml)}
```

- `${components.infra.sns_topic_arn}` uses the `sns_topic_arn` Terraform output as a value for the payment component
- `${var.stripe_secret}` reads the `stripe_secret` from a variables file
- `${include(components.yml)}` includes `components.yml` and injects it in the configuration

## `component`
**Usage** `${component.<component-name>.<output-value>}`

You can use this to refer to any [Terraform output](https://www.terraform.io/docs/language/values/outputs.html) that another component has defined.

So for example if a component called "infra" has the following outputs:

```terraform
# outputs.tf

output "sns_topic_arn" {
    value = aws_sns_topic.main.arn
}

output "psql_server" {
    value = {
        endpoint = aws_db_instance.main.endpoint
        arn = aws_db_instance.main.arn
    }
}
```

These can then be used in the configuration:

```yaml
components:
  - name: order-notifier
    variables:
      sns_topic: ${component.infra.sns_topic_arn}
      database_endpoint: ${component.psql_server.endpoint}
```

## `var`
**Usage** `${var.<variable-key>}`

This can be used for using values from a *variables file*. This variable file must be set by using the [`--var-file` CLI option](./cli.md#apply):

```bash
mach apply -f main.yml --var-file variables.yml
```

From the [example](#example) above, the following configuration line:
```yaml
stripe_secret_key: ${var.stripe_secret}
```

will use the `stripe_secret` value from the given variables file. 

These values can be nested, so it's possible to define a `${var.site1.stripe.secret_key}` with your `variables.yml` looking like:

### Note on encryption
    You can [encrypt your `variables.yml` using SOPS](../howto/security/encrypt.md#encrypted-variables).

    When doing so, MACH won't render the variable files directly into your Terraform configuration but uses [terraform-sops](https://github.com/carlpett/terraform-provider-sops) to refer you the SOPS encrypted variables within the Terraform file.


## `env`
**Usage** `${env.<variable-name>}`

Use environment variables in your MACH configuration:

```bash
export MACH_ENVIRONMENT=test
mach apply
```

Will replace `${env.MACH_ENVIRONMENT}` in our [example](#example) with `test`.

## `include`
**Usage** `${include(<filename>)}`

Any valid YAML file can be included here.
