### PR TITLE
Provide frontdoor routing details via component output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 **Azure**
 
+- Add extra Frontdoor routing options to components such as:
+  - Custom routing paths
+  - Health probe settings
+  - Custom host address and ports
+  - Caching options
 - Upgraded Terraform Azure provider to [`2.60.0`](https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/CHANGELOG.md#2600-may-20-2021)
 - Include `frontend_endpoint` in ignore list when `suppress_changes` is used
 - Add Frontdoor `ssl_key_vault` option to supply your own SSL certificate for your endpoints
@@ -20,9 +25,18 @@
 
 **For Azure**
 
-Changes have been made in the Frontdoor configuration in the underlying Terraform Azure provider.<br>
-If you are using endpoints with a custom domain, you'll need to import the new [`azurerm_frontdoor_custom_https_configuration`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/frontdoor_custom_https_configuration#import) into your Terraform state.<br>
-More on how to work with the Terraform state in [our troubleshooting guide](https://docs.machcomposer.io/topics/development/troubleshooting.html).
+- Each component that has an `endpoint` defined needs to have an Terraform output defined for that endpoint. For example:<br>
+  ```terraform
+  output "azure_endpoint_main" {
+    value = {
+      address = azurerm_function_app.main.default_hostname
+    }
+  }
+  ```
+  Read more about the [configuration options](https://docs.machcomposer.io/reference/components/azure.html#defining-outputs).
+- Changes have been made in the Frontdoor configuration in the underlying Terraform Azure provider.<br>
+  If you are using endpoints with a custom domain, you'll need to import the new [`azurerm_frontdoor_custom_https_configuration`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/frontdoor_custom_https_configuration#import) into your Terraform state.<br>
+  More on how to work with the Terraform state in [our troubleshooting guide](https://docs.machcomposer.io/topics/development/troubleshooting.html).
 
 
 

--- a/docs/src/_css/custom.css
+++ b/docs/src/_css/custom.css
@@ -18,3 +18,7 @@ h2, h3 {
 h2 {
     border-bottom: 1px solid #e7e7ff;
 }
+
+h2:not(:first-of-type) {
+    padding-top: 20px;
+}

--- a/docs/src/reference/components/azure.md
+++ b/docs/src/reference/components/azure.md
@@ -107,7 +107,10 @@ This output needs to have a name in the form of `azure_endpoint_<endpoint-name>`
 - `https_port` - The HTTPS TCP port number. Possible values are between `1` - `65535`. Defaults to `443`.
 - `health_probe_path` - The path to use for the Health Probe. If left empty, health probe won't be enabled.
 - `health_probe_protocol` - Protocol scheme to use for the Health Probe. Defaults to `Http`
-- `health_probe_method` - Specifies HTTP method the health probe uses when querying the service. Possible values include: `Get` and `Head`. Defaults to `Get`.
+- `health_probe_method` - Specifies HTTP method the health probe uses when querying the service. Possible values include: `GET` and `HEAD`. Defaults to `GET`.
+- `cache_enabled` - Specifies whether to Enable caching or not. Valid options are `true` or `false`. Defaults to `false`.
+- `custom_forwarding_path` - Path to use when constructing the request to forward to the backend. This functions as a URL Rewrite. Default behaviour preserves the URL path.
+
 
 **Full example**
 ```terraform
@@ -121,6 +124,7 @@ output "azure_endpoint_main" {
    health_probe_method = "Get"
    host_header = "www.example.com/something-else/"
    https_port = 9000
+   cache_enabled = true
   }
 }
 ```

--- a/docs/src/reference/components/azure.md
+++ b/docs/src/reference/components/azure.md
@@ -60,9 +60,9 @@ variable "azure_monitor_action_group_id" {
 
 ### With `endpoints`
 
-In order to support the [`endpoints`](../../topics/deployment/config/azure.md#http-routing) attribute on the component, the component needs to define what endpoints it expects.
+In order to support the [`endpoints`](../../topics/deployment/config/azure.md#http-routing) attribute on the component, the component needs to define what endpoints it expects **and** needs to provide output about the [routing options](../../topics/deployment/config/azure.md#http-routing).
 
-For example, if the component requires two endpoints (`main` and `webhooks`) to be set, the following variables needs to be defined:
+For example, if the component requires two endpoints (`main` and `webhooks`) to be set, the following variables and outputs needs to be defined:
 
 ```terraform
 variable "azure_endpoint_main" {
@@ -77,6 +77,51 @@ variable "azure_endpoint_webhooks" {
     url          = string
     frontdoor_id = string
   })
+}
+
+output "azure_endpoint_main" {
+  value = {
+    address = azurerm_app_service.main.default_site_hostname
+  }
+}
+
+output "azure_endpoint_webhooks" {
+  value = {
+    address = azurerm_app_service.main.default_site_hostname
+    routing_patterns = [
+      "/hooks/*",
+    ]
+  }
+}
+```
+
+#### Defining `outputs`
+
+As shown in the example above, the component needs to have an output *per endpoint* defined in order to instruct MACH how to setup Frontdoor routing.
+
+This output needs to have a name in the form of `azure_endpoint_<endpoint-name>` and contain the following attributes:
+
+- **`address`** - (Required) The host address to route traffic to
+- `host_header` - The value to use as the host header sent to the backend. By default will take the value of `address`.
+- `http_port` -  The HTTP TCP port number. Possible values are between `1` - `65535`. Defaults to `80`.
+- `https_port` - The HTTPS TCP port number. Possible values are between `1` - `65535`. Defaults to `443`.
+- `health_probe_path` - The path to use for the Health Probe. If left empty, health probe won't be enabled.
+- `health_probe_protocol` - Protocol scheme to use for the Health Probe. Defaults to `Http`
+- `health_probe_method` - Specifies HTTP method the health probe uses when querying the service. Possible values include: `Get` and `Head`. Defaults to `Get`.
+
+**Full example**
+```terraform
+output "azure_endpoint_main" {
+  value = {
+    address = azurerm_app_service.main.default_site_hostname
+    routing_patterns = [
+      "/graphql/*",
+    ]
+   health_probe_path = "/"
+   health_probe_method = "Get"
+   host_header = "www.example.com/something-else/"
+   https_port = 9000
+  }
 }
 ```
 

--- a/docs/src/topics/deployment/config/azure.md
+++ b/docs/src/topics/deployment/config/azure.md
@@ -15,7 +15,7 @@ Only when a MACH stack contains components that have an [`endpoint`](../../../re
 
 If you have defined your component with a `default` endpoint, MACH will create a Frontdoor instance for you which includes the default Azure domain.
 
-```
+```yaml
 components:
   - name: payment
     source: git::ssh://git@github.com/your-project/components/payment-component.git//terraform
@@ -33,7 +33,7 @@ Whenever a custom endpoint from your [endpoints definition](../../../reference/s
 
 In addition to that it will also setup the necessary DNS record.
 
-### Routes to the component
+### Component routing
 
 For each component with an `endpoint` MACH composer will add a route to the Frontdoor instance using the name of the component.
 
@@ -59,6 +59,11 @@ components:
 The routing in Frontdoor that will be created:
 
 ![Frontdoor routes](../../../_img/azure/frontdoor_routes.png)
+
+!!! tip "Frontdoor resource"
+    An important thing to keep in mind is that the [Frontdoor resource](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/frontdoor) in Terraform is managed as a single resource, including all the routing to the components.
+
+    This means the components can't create the routing themselves (as with AWS) but need to instruct MACH how to set up routing. This can be done by defining routing options in [output values](../../../reference/components/azure.md#defining-outputs).
 
 ## App service plans
 

--- a/src/mach/templates/partials/endpoints/azure_frontdoor_endpoint.tf
+++ b/src/mach/templates/partials/endpoints/azure_frontdoor_endpoint.tf
@@ -4,7 +4,7 @@ backend_pool_health_probe {
   path = lookup(module.{{ component.name }}.azure_endpoint_{{ endpoint.key }}, "health_probe_path", "/")
   protocol = lookup(module.{{ component.name }}.azure_endpoint_{{ endpoint.key }}, "health_probe_protocol", "Https")
   enabled = contains(keys(module.{{ component.name }}.azure_endpoint_{{ endpoint.key }}), "health_probe_path")
-  probe_method = lookup(module.{{ component.name }}.azure_endpoint_{{ endpoint.key }}, "health_probe_method", "HEAD")
+  probe_method = lookup(module.{{ component.name }}.azure_endpoint_{{ endpoint.key }}, "health_probe_method", "Get")
 }
 
 routing_rule {

--- a/src/mach/templates/partials/endpoints/azure_frontdoor_endpoint.tf
+++ b/src/mach/templates/partials/endpoints/azure_frontdoor_endpoint.tf
@@ -4,7 +4,7 @@ backend_pool_health_probe {
   path = lookup(module.{{ component.name }}.azure_endpoint_{{ endpoint.key }}, "health_probe_path", "/")
   protocol = lookup(module.{{ component.name }}.azure_endpoint_{{ endpoint.key }}, "health_probe_protocol", "Https")
   enabled = contains(keys(module.{{ component.name }}.azure_endpoint_{{ endpoint.key }}), "health_probe_path")
-  probe_method = lookup(module.{{ component.name }}.azure_endpoint_{{ endpoint.key }}, "health_probe_method", "Get")
+  probe_method = lookup(module.{{ component.name }}.azure_endpoint_{{ endpoint.key }}, "health_probe_method", "GET")
 }
 
 routing_rule {
@@ -18,8 +18,10 @@ routing_rule {
     {% endif %}
   ]
   forwarding_configuration {
-      forwarding_protocol = "MatchRequest"
-      backend_pool_name   = "{{ endpoint.key }}-{{ component.name }}"
+      forwarding_protocol            = "MatchRequest"
+      backend_pool_name              = "{{ endpoint.key }}-{{ component.name }}"
+      cache_enabled                  = lookup(module.{{ component.name }}.azure_endpoint_{{ endpoint.key }}, "cache_enabled", false)
+      custom_forwarding_path         = lookup(module.{{ component.name }}.azure_endpoint_{{ endpoint.key }}, "custom_forwarding_path", null)
   }
 }
 

--- a/tests/files/azure_config1_expected_mach-site-eu.json
+++ b/tests/files/azure_config1_expected_mach-site-eu.json
@@ -283,7 +283,7 @@
                 "${contains(keys(module.us-payment.azure_endpoint_default),\"health_probe_path\")}"
               ],
               "probe_method": [
-                "${lookup(module.us-payment.azure_endpoint_default,\"health_probe_method\",\"HEAD\")}"
+                "${lookup(module.us-payment.azure_endpoint_default,\"health_probe_method\",\"Get\")}"
               ]
             }
           ],

--- a/tests/files/azure_config1_expected_mach-site-eu.json
+++ b/tests/files/azure_config1_expected_mach-site-eu.json
@@ -249,9 +249,7 @@
                 ]
               ],
               "patterns_to_match": [
-                [
-                  "/us-payment/*"
-                ]
+                "${lookup(module.us-payment.azure_endpoint_default,\"routing_patterns\",['/us-payment/*'])}"
               ],
               "frontend_endpoints": [
                 [
@@ -276,16 +274,16 @@
                 "default-us-payment-hpSettings"
               ],
               "path": [
-                "/us-payment/healthchecks"
+                "${lookup(module.us-payment.azure_endpoint_default,\"health_probe_path\",\"/\")}"
               ],
               "protocol": [
-                "Https"
+                "${lookup(module.us-payment.azure_endpoint_default,\"health_probe_protocol\",\"Https\")}"
               ],
               "enabled": [
-                false
+                "${contains(keys(module.us-payment.azure_endpoint_default),\"health_probe_path\")}"
               ],
               "probe_method": [
-                "HEAD"
+                "${lookup(module.us-payment.azure_endpoint_default,\"health_probe_method\",\"HEAD\")}"
               ]
             }
           ],
@@ -297,16 +295,16 @@
               "backend": [
                 {
                   "host_header": [
-                    "${local.name_prefix}-func-us-payment.azurewebsites.net"
+                    "${lookup(module.us-payment.azure_endpoint_default,\"host_header\",module.us-payment.azure_endpoint_default.address)}"
                   ],
                   "address": [
-                    "${local.name_prefix}-func-us-payment.azurewebsites.net"
+                    "${module.us-payment.azure_endpoint_default.address}"
                   ],
                   "http_port": [
-                    80
+                    "${lookup(module.us-payment.azure_endpoint_default,\"http_port\",80)}"
                   ],
                   "https_port": [
-                    443
+                    "${lookup(module.us-payment.azure_endpoint_default,\"https_port\",443)}"
                   ]
                 }
               ],

--- a/tests/files/azure_config1_expected_mach-site-eu.json
+++ b/tests/files/azure_config1_expected_mach-site-eu.json
@@ -263,6 +263,12 @@
                   ],
                   "backend_pool_name": [
                     "default-us-payment"
+                  ],
+                  "cache_enabled": [
+                    "${lookup(module.us-payment.azure_endpoint_default,\"cache_enabled\",False)}"
+                  ],
+                  "custom_forwarding_path": [
+                    "${lookup(module.us-payment.azure_endpoint_default,\"custom_forwarding_path\",None)}"
                   ]
                 }
               ]
@@ -283,7 +289,7 @@
                 "${contains(keys(module.us-payment.azure_endpoint_default),\"health_probe_path\")}"
               ],
               "probe_method": [
-                "${lookup(module.us-payment.azure_endpoint_default,\"health_probe_method\",\"Get\")}"
+                "${lookup(module.us-payment.azure_endpoint_default,\"health_probe_method\",\"GET\")}"
               ]
             }
           ],

--- a/tests/files/azure_config1_expected_mach-site-us.json
+++ b/tests/files/azure_config1_expected_mach-site-us.json
@@ -313,7 +313,7 @@
                 "${contains(keys(module.payment.azure_endpoint_public),\"health_probe_path\")}"
               ],
               "probe_method": [
-                "${lookup(module.payment.azure_endpoint_public,\"health_probe_method\",\"HEAD\")}"
+                "${lookup(module.payment.azure_endpoint_public,\"health_probe_method\",\"Get\")}"
               ]
             }
           ],

--- a/tests/files/azure_config1_expected_mach-site-us.json
+++ b/tests/files/azure_config1_expected_mach-site-us.json
@@ -278,9 +278,7 @@
                 ]
               ],
               "patterns_to_match": [
-                [
-                  "/payment/*"
-                ]
+                "${lookup(module.payment.azure_endpoint_public,\"routing_patterns\",['/payment/*'])}"
               ],
               "frontend_endpoints": [
                 [
@@ -306,16 +304,16 @@
                 "public-payment-hpSettings"
               ],
               "path": [
-                "/payment/healthchecks"
+                "${lookup(module.payment.azure_endpoint_public,\"health_probe_path\",\"/\")}"
               ],
               "protocol": [
-                "Https"
+                "${lookup(module.payment.azure_endpoint_public,\"health_probe_protocol\",\"Https\")}"
               ],
               "enabled": [
-                false
+                "${contains(keys(module.payment.azure_endpoint_public),\"health_probe_path\")}"
               ],
               "probe_method": [
-                "HEAD"
+                "${lookup(module.payment.azure_endpoint_public,\"health_probe_method\",\"HEAD\")}"
               ]
             }
           ],
@@ -327,16 +325,16 @@
               "backend": [
                 {
                   "host_header": [
-                    "${local.name_prefix}-func-payment.azurewebsites.net"
+                    "${lookup(module.payment.azure_endpoint_public,\"host_header\",module.payment.azure_endpoint_public.address)}"
                   ],
                   "address": [
-                    "${local.name_prefix}-func-payment.azurewebsites.net"
+                    "${module.payment.azure_endpoint_public.address}"
                   ],
                   "http_port": [
-                    80
+                    "${lookup(module.payment.azure_endpoint_public,\"http_port\",80)}"
                   ],
                   "https_port": [
-                    443
+                    "${lookup(module.payment.azure_endpoint_public,\"https_port\",443)}"
                   ]
                 }
               ],

--- a/tests/files/azure_config1_expected_mach-site-us.json
+++ b/tests/files/azure_config1_expected_mach-site-us.json
@@ -293,6 +293,12 @@
                   ],
                   "backend_pool_name": [
                     "public-payment"
+                  ],
+                  "cache_enabled": [
+                    "${lookup(module.payment.azure_endpoint_public,\"cache_enabled\",False)}"
+                  ],
+                  "custom_forwarding_path": [
+                    "${lookup(module.payment.azure_endpoint_public,\"custom_forwarding_path\",None)}"
                   ]
                 }
               ]
@@ -313,7 +319,7 @@
                 "${contains(keys(module.payment.azure_endpoint_public),\"health_probe_path\")}"
               ],
               "probe_method": [
-                "${lookup(module.payment.azure_endpoint_public,\"health_probe_method\",\"Get\")}"
+                "${lookup(module.payment.azure_endpoint_public,\"health_probe_method\",\"GET\")}"
               ]
             }
           ],


### PR DESCRIPTION
This PR will make it possible to have more control over the Frontdoor routing.

Since Frontdoor has to be deployed as 1 resource, it's not possible to define component-routes within the component.
Up until now MACH made educated guesses on what address to route to, what path to use, etc.
But in many cases these are not sufficient, and it would be desirable for a component to have some more control over routing (paths, protocols, health checks, etc).

This change will require each component that uses an `endpoint` to define a Terraform output like so;

At bare **minimum**
```hcl
output "azure_endpoint_main" {
  value = {
    address = azurerm_app_service.main.default_site_hostname
  }
}
```

And could be extended with:

```hcl
output "azure_endpoint_main" {
  value = {
    address = azurerm_app_service.main.default_site_hostname
    routing_patterns = [
      "/graphql/*",
    ]
   health_probe_path = "/api/healthchecks"
   health_probe_method = "Get"
   host_header = "www.example.com/something-else/"
   https_port = 9000
  }
}
```