### PR TITLE
add commercetools tax_categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - Include `frontend_endpoint` in ignore list when `suppress_changes` is used
 - Add Frontdoor `ssl_key_vault` option to supply your own SSL certificate for your endpoints
 
+**Commercetools**
+
+- Add `tax_categories` to allow more complex tax setups. Does not work in conjunction with `taxes`
+
 ### Upgrade notes
 
 **For Azure**

--- a/docs/src/reference/syntax/sites.md
+++ b/docs/src/reference/syntax/sites.md
@@ -69,6 +69,7 @@ commercetools:
 - `api_url` - Defaults to `https://api.europe-west1.gcp.commercetools.com`
 - `channels` - List of [channel definitions](#channels)
 - `taxes` - List of [tax definitions](#taxes)
+- `tax_categories` - List of [tax_category definitions](#tax_categories)
 - `zones` - List of [zone definitions](#zones)
 - `stores` - List of [store definitions](#stores) if multiple (store) contexts are going to be used.
 - `frontend` - [Frontend configuration block](#frontend)
@@ -161,13 +162,53 @@ zones:
   
 ### taxes
 
-Defines tax rates for various countries.
+Defines tax rates for various countries but will only create a single tax category.
+Please see [tax_categories](#tax_categories) for setups demanding multiple tax categories.
+
+**Cannot be used in conjunction with `tax_categories`**
 
 - **`country`** - (Required) A two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
 - **`amount`** - (Required) Number Percentage in the range of [0..1]
 - **`name`** - (Required) Tax rate name
+- **`included_in_price`** - Tax included in price
+
+### tax_categories
+
+Defines [commercetools tax categories](https://docs.commercetools.com/tutorials/explore-merchant-center#creating-tax-categories) with commercetools tax rates.
+
+**Cannot be used in conjunction with `taxes`**
+
+Example:
+```yaml
+tax_categories:
+- name: Non-standard taxes
+  key: non-standard-taxes
+  rates:
+  - name: rate 2
+    amount: 0.02
+    country: GB
+    included_in_price: false
+  - name: rate 10
+    amount: 0.1
+    country: NL
+    included_in_price: true
+- name: Standard taxes
+  key: some-standard
+  rates:
+  - name: rate 21
+    amount: 0.21
+    country: GB
+  - name: rate 6
+    amount: 0.06
+    country: NL
+```
+
+- **`name`** - (Required) Name of the category
+- **`key`** - (Required) Key of the category
+- **`rates`** - List of [tax rates](#taxes)
 
 ### stores
+
 Defines [commercetools stores](https://docs.commercetools.com/http-api-projects-stores).
 
 Example:

--- a/src/mach/templates/partials/commercetools.tf
+++ b/src/mach/templates/partials/commercetools.tf
@@ -44,6 +44,24 @@ resource "commercetools_channel" "{{ channel.key }}" {
 }
 {% endfor %}
 
+{% for tax_category in commercetools.tax_categories %}
+resource "commercetools_tax_category" "{{ tax_category.key|lower }}" {
+  name = {{ tax_category.name|tf }}
+  key = {{ tax_category.key|tf }}
+}
+
+{% for rate in tax_category.rates %}
+resource "commercetools_tax_category_rate" "{{ rate.name|slugify }}" {
+  tax_category_id = commercetools_tax_category.{{ tax_category.key|lower }}.id
+  name = {{ rate.name|tf }}
+  amount = {{ rate.amount|tf }}
+  country = "{{ rate.country }}"
+  included_in_price = {{ rate.included_in_price|tf }}
+}
+
+{% endfor %}
+{% endfor %}
+
 {% if commercetools.taxes %}
 resource "commercetools_tax_category" "standard" {
   name = "Standard tax category"

--- a/src/mach/types/sites.py
+++ b/src/mach/types/sites.py
@@ -32,6 +32,7 @@ __all__ = [
     "CommercetoolsStore",
     "CommercetoolsChannel",
     "CommercetoolsTax",
+    "CommercetoolsTaxCategory",
     "CommercetoolsProjectSettings",
     "CommercetoolsFrontendSettings",
     "CommercetoolsSettings",
@@ -162,6 +163,17 @@ class CommercetoolsTax(JsonSchemaMixin):
     country: str
     amount: float
     name: str
+    included_in_price: Optional[bool] = True
+
+
+@dataclass_json
+@dataclass
+class CommercetoolsTaxCategory(JsonSchemaMixin):
+    """commercetools tax categories definition."""
+
+    key: str
+    name: str
+    rates: Optional[List[CommercetoolsTax]] = fields.list_()
 
 
 @dataclass_json
@@ -229,6 +241,7 @@ class CommercetoolsSettings(JsonSchemaMixin):
 
     channels: Optional[List[CommercetoolsChannel]] = fields.list_()
     taxes: Optional[List[CommercetoolsTax]] = fields.list_()
+    tax_categories: Optional[List[CommercetoolsTaxCategory]] = fields.list_()
     stores: List[CommercetoolsStore] = fields.list_()
     zones: List[CommercetoolsZone] = fields.list_()
 

--- a/src/mach/validate.py
+++ b/src/mach/validate.py
@@ -133,6 +133,7 @@ def validate_site_components(components: List[types.Component], *, site: types.S
 def validate_commercetools(site: types.Site):
     if site.commercetools:
         validate_store_keys(site.commercetools)
+        validate_taxes(site.commercetools)
 
 
 def validate_store_keys(ct_settings: types.CommercetoolsSettings):
@@ -151,6 +152,12 @@ def validate_store_keys(ct_settings: types.CommercetoolsSettings):
                 raise ValidationError(
                     f"Store key {key} may only contain alphanumeric characters or underscores"
                 )
+
+
+def validate_taxes(ct_settings: types.CommercetoolsSettings):
+    """Ensure either `taxes` or `tax_categories` are used."""
+    if ct_settings.taxes and ct_settings.tax_categories:
+        raise ValidationError("`taxes` and `tax_categories` are mutually exclusive.")
 
 
 def validate_components(config: types.MachConfig):

--- a/tests/unittests/test_validate.py
+++ b/tests/unittests/test_validate.py
@@ -201,6 +201,45 @@ def test_validate_stores(parsed_config: types.MachConfig):
     validate.validate_config(config)
 
 
+def test_validate_taxes_tax_categories(parsed_config: types.MachConfig):
+    """Tests if an error is raised when taxes and tax_categories are used in conjunction."""
+    config = parsed_config
+    site = config.sites[0]
+
+    site.commercetools = types.CommercetoolsSettings(
+        project_key="ct-unit-test",
+        client_id="a96e59be-24da-4f41-a6cf-d61d7b6e1766",
+        client_secret="98c32de8-1a6c-45a9-a718-d3cce5201799",
+        scopes="manage_project:ct-unit-test",
+        project_settings=types.CommercetoolsProjectSettings(
+            languages=["nl-NL"],
+            countries=["NL"],
+            currencies=["EUR"],
+        ),
+        taxes=[types.CommercetoolsTax(name="foo tax", amount=1, country="NL")],
+    )
+
+    validate.validate_commercetools(site)
+
+    site.commercetools.tax_categories = [
+        types.CommercetoolsTaxCategory(
+            name="foo category",
+            key="foo-key",
+            rates=[
+                types.CommercetoolsTax(
+                    name="foo category tax",
+                    amount=2,
+                    country="NL",
+                    included_in_price=True,
+                )
+            ],
+        )
+    ]
+
+    with pytest.raises(ValidationError):
+        validate.validate_commercetools(site)
+
+
 def test_validate_azure_service_plans(parsed_azure_config: types.MachConfig):
     config = parsed_azure_config
     config.components[0].azure.service_plan = "premium"


### PR DESCRIPTION
Add `tax_categories` for commercetools but do not break old `taxes` as to keep backward compatibility.