### PR TITLE
added terraform init command support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2 (unreleased)
 
 - Ignore missing variables when running `mach sites` and `mach components`
+- Add terraform init command support
 
 **AWS**
 - Add support for default tags on provider level

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ To generate the files:
 
 `mach generate -f main.yml`
 
+To init Terraform (optional):
+
+`mach init`
+
 To plan Terraform:
 
 `mach plan`

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -14,6 +14,7 @@ Commands:
   bootstrap   Bootstraps a configuration or component.
   components  List all components.
   generate    Generate the Terraform files.
+  init        Init the Terraform directory.
   plan        Output the deploy plan.
   sites       List all sites.
   update      Update all (or a given) component.
@@ -77,6 +78,22 @@ Generate the Terraform files.
 
 ```bash
 mach generate -f main.yml
+```
+
+**Options**
+
+- `--file` or `-f TEXT` YAML file to parse. If not set parse all *.yml files.
+- `--var-file` YAML file with variables to be used in the configuration file.
+- `--site` or `-s TEXT` Site to parse. If not set parse all sites.
+- `--output-path TEXT` Output path, defaults to `cwd`/deployments.
+- `--ignore-version` Skip MACH composer version check
+
+
+## `init`
+Initiliaze the Terraform directory.
+
+```bash
+mach init -f main.yml
 ```
 
 **Options**

--- a/src/mach/commands.py
+++ b/src/mach/commands.py
@@ -10,7 +10,12 @@ from mach import git, parse, updater
 from mach.__version__ import __version__
 from mach.build import build_packages
 from mach.exceptions import MachError
-from mach.terraform import apply_terraform, generate_terraform, plan_terraform
+from mach.terraform import (
+    apply_terraform,
+    generate_terraform,
+    init_terraform,
+    plan_terraform,
+)
 from mach.variables import ignore_variable_not_found
 
 
@@ -93,6 +98,14 @@ def generate(file, site, configs, *args, **kwargs):
     """Generate the Terraform files."""
     for config in configs:
         generate_terraform(config, site=site)
+
+
+@mach.command()
+@terraform_command
+def init(file, site, configs, *args, **kwargs):
+    """Initialize site directories Terraform files."""
+    for config in configs:
+        init_terraform(config, site=site)
 
 
 @mach.command()

--- a/src/mach/terraform.py
+++ b/src/mach/terraform.py
@@ -48,6 +48,19 @@ def _clean_tf(content: str) -> str:
     return re.sub(r"\{(\s*)\}", "{}", content)
 
 
+def init_terraform(config: MachConfig, *, site: str = None):
+    """Terraform init for all generated sites."""
+    sites = _filter_sites(config.sites, site)
+    for s in sites:
+        site_dir = config.deployment_path / Path(s.identifier)
+        if not site_dir.is_dir():
+            click.echo(f"Could not find site directory {site_dir}")
+            continue
+
+        click.echo(f"Terraform init for {site_dir.name}")
+        run_terraform("init", site_dir)
+
+
 def plan_terraform(
     config: MachConfig,
     *,


### PR DESCRIPTION
This is so we can run security scanners like tfsec on downloaded modules as well without hitting providers api by using the plan command