### PR TITLE
Implement the `mach-composer terraform` command.

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -11,7 +11,6 @@ var generateCmd = &cobra.Command{
 	PreRun: func(cmd *cobra.Command, args []string) {
 		preprocessGenerateFlags()
 	},
-
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := generateFunc(args); err != nil {
 			return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,5 +33,6 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(planCmd)
 	rootCmd.AddCommand(updateCmd)
+	rootCmd.AddCommand(terraformCmd)
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"github.com/labd/mach-composer/generator"
+	"github.com/labd/mach-composer/runner"
+	"github.com/spf13/cobra"
+)
+
+var terraformCmd = &cobra.Command{
+	Use:   "terraform",
+	Short: "Execute terraform commands directly",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		preprocessGenerateFlags()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := terraformFunc(args); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	registerGenerateFlags(terraformCmd)
+	terraformCmd.MarkFlagRequired("site")
+}
+
+func terraformFunc(args []string) error {
+
+	allPaths := make(map[string]map[string]string)
+	configs := LoadConfigs()
+
+	generateFlags.ValidateSite(configs)
+
+	// Write the generate files for each config
+	genOptions := &generator.GenerateOptions{
+		OutputPath: generateFlags.outputPath,
+		Site:       generateFlags.siteName,
+	}
+
+	for _, filename := range generateFlags.fileNames {
+		cfg := configs[filename]
+		allPaths[filename] = generator.FileLocations(cfg, genOptions)
+	}
+
+	for _, filename := range generateFlags.fileNames {
+		cfg := configs[filename]
+		paths := allPaths[filename]
+		runner.TerraformProxy(cfg, paths, generateFlags.siteName, args)
+	}
+
+	return nil
+}

--- a/generator/writer_test.go
+++ b/generator/writer_test.go
@@ -1,0 +1,29 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/labd/mach-composer/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileLocations(t *testing.T) {
+	cfg := &config.MachConfig{
+		Sites: []config.Site{
+			{
+				Identifier: "my-site",
+			},
+		},
+	}
+
+	options := &GenerateOptions{
+		OutputPath: "deployments/something",
+	}
+
+	actual := FileLocations(cfg, options)
+	expected := map[string]string{
+		"my-site": "deployments/something/my-site",
+	}
+
+	assert.EqualValues(t, expected, actual)
+}

--- a/runner/apply.go
+++ b/runner/apply.go
@@ -31,6 +31,20 @@ func TerraformApply(cfg *config.MachConfig, locations map[string]string, options
 	}
 }
 
+func TerraformProxy(cfg *config.MachConfig, locations map[string]string, siteName string, cmd []string) {
+	ctx := context.Background()
+
+	for i := range cfg.Sites {
+		site := cfg.Sites[i]
+
+		if siteName != "" && site.Identifier != siteName {
+			continue
+		}
+
+		RunTerraform(ctx, locations[site.Identifier], cmd...)
+	}
+}
+
 func TerraformApplySite(ctx context.Context, cfg *config.MachConfig, site *config.Site, path string, options *ApplyOptions) {
 
 	if !options.Reuse {

--- a/runner/exec.go
+++ b/runner/exec.go
@@ -2,10 +2,19 @@ package runner
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/labd/mach-composer/utils"
 )
 
 func RunTerraform(ctx context.Context, cwd string, args ...string) {
+	if _, err := os.Stat(cwd); err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintln(os.Stderr, "The generated files are not found. Did you run mach-composer generate?")
+			os.Exit(1)
+		}
+	}
+
 	utils.RunInteractive(ctx, "terraform", cwd, args...)
 }


### PR DESCRIPTION
This command proxies the arguments to terraform in the generated path.
Useful for various debugging activities