### PR TITLE
feat(commercetools frontend): deprecate this functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2 (unreleased)
+- Deprecate `commercetools.frontend` block, will be removed in a later release.
+
 ## 2.1.1 (2022-04-22)
 - Don't crash when running `mach-composer apply` without `--auto-approve`
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -80,7 +80,17 @@ func LoadConfigs() map[string]*config.MachConfig {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)
 		}
+		CheckDeprecations(cfg)
 		configs[filename] = cfg
 	}
 	return configs
+}
+
+// CheckDeprecations warns if features have been deprecated
+func CheckDeprecations(cfg *config.MachConfig) {
+	for _, site := range cfg.Sites {
+		if site.Commercetools.Frontend != nil {
+			fmt.Println("[WARN] Site", site.Identifier, "commercetools frontend block is deprecated and will be removed soon")
+		}
+	}
 }

--- a/config/types_commercetools.go
+++ b/config/types_commercetools.go
@@ -38,7 +38,7 @@ type CommercetoolsProjectSettings struct {
 }
 
 type CommercetoolsFrontendSettings struct {
-	CreateCredentials bool     `yaml:"create_credentials" default:"true"`
+	CreateCredentials bool     `yaml:"create_credentials" default:"false"`
 	PermissionScopes  []string `yaml:"permission_scopes"`
 }
 

--- a/docs/src/reference/syntax/sites.md
+++ b/docs/src/reference/syntax/sites.md
@@ -271,6 +271,12 @@ Example:
 
 ### frontend
 
+!!! warning
+This functionality is deprecated and will be removed soon.
+
+Create your own frontend tokens in the commercetools Merchant Center. 
+Once this functionality is removed the generated frontend tokens will be automatically deleted on rollout.
+
 Example:
 ```yaml
 frontend:


### PR DESCRIPTION
Creating frontend credentials is not an often used version, so it has been decided to deprecate it.