### PR TITLE
fix: use the branch configuration on component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.2.1 (2022-06-10)
+- Fixed inconsistencies between 1.2 and 2.x:
+  - Add `branch` option to component definitions to be able to perform a `mach
+    update` and stay within a certain branch (during development)
+
+
 ## 2.2 (2022-06-10)
 - Fixed inconsistencies between 1.2 and 2.x:
   - Upgrade Terraform providers in golang version of the MACH composer to match the 1.2 release:
@@ -10,6 +16,7 @@
   - Fix auto add cloud integration (aws or azure) when `integration` list is left empty
   - Add ability to define a custom provider version including the version operator
 - Deprecate `commercetools.frontend` block, will be removed in a later release.
+
 
 ## 2.1.1 (2022-04-22)
 - Don't crash when running `mach-composer apply` without `--auto-approve`
@@ -41,7 +48,6 @@ A number of features which were minimal used are removed.
   - The `--ignore-version` flag is removed. The version in the config file now
     indicates a schema version. Only version 1 is supported and updates within
     this schema version should always be backwards compatible.
-
 
 
 ## 1.2 (2022-04-11)

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -135,6 +135,7 @@ func TestParse(t *testing.T) {
 				Name:         "your-component",
 				Source:       "git::https://github.com/<username>/<your-component>.git//terraform",
 				Version:      "0.1.0",
+				Branch:       "develop",
 				Integrations: []string{"aws", "commercetools"},
 				Endpoints: map[string]string{
 					"internal": "internal",

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -135,7 +135,7 @@ func TestParse(t *testing.T) {
 				Name:         "your-component",
 				Source:       "git::https://github.com/<username>/<your-component>.git//terraform",
 				Version:      "0.1.0",
-				Branch:       "develop",
+				Branch:       "",
 				Integrations: []string{"aws", "commercetools"},
 				Endpoints: map[string]string{
 					"internal": "internal",

--- a/config/types_config.go
+++ b/config/types_config.go
@@ -44,6 +44,7 @@ type Component struct {
 	Name         string
 	Source       string
 	Version      string `yaml:"version"`
+	Branch       string
 	Integrations []string
 	Endpoints    map[string]string `yaml:"endpoints"`
 

--- a/updater/git.go
+++ b/updater/git.go
@@ -44,8 +44,12 @@ func GetLastVersionGit(ctx context.Context, c *config.Component, origin string) 
 		return nil, fmt.Errorf("cannot check %s component since it doesn't have a Git source defined", c.Name)
 	}
 
+	var branch string = "HEAD"
+	if c.Branch != "" {
+		branch = c.Branch
+	}
 	fetchGitRepository(ctx, source, cacheDir)
-	commits := loadGitHistory(ctx, source, c.Version, "HEAD", cacheDir)
+	commits := loadGitHistory(ctx, source, c.Version, branch, cacheDir)
 
 	cs := &ChangeSet{
 		Changes:   commits,

--- a/updater/git.go
+++ b/updater/git.go
@@ -44,7 +44,7 @@ func GetLastVersionGit(ctx context.Context, c *config.Component, origin string) 
 		return nil, fmt.Errorf("cannot check %s component since it doesn't have a Git source defined", c.Name)
 	}
 
-	var branch string = "HEAD"
+	branch := "HEAD"
 	if c.Branch != "" {
 		branch = c.Branch
 	}


### PR DESCRIPTION
The docs specify components can specify a branch to follow. The current go-code only follows HEAD.
HEAD is maintained as default, but branch is now tracked correctly.