### PR TITLE
Fixed depends_on reference to non-existent commercetools_store resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed inconsistencies between 1.2 and 2.x:
   - Add `branch` option to component definitions to be able to perform a `mach
     update` and stay within a certain branch (during development)
+- Fixed depends_on reference to non-existent commercetools_store resource
 
 
 ## 2.2 (2022-06-10)

--- a/generator/templates/services/commercetools/main.tf
+++ b/generator/templates/services/commercetools/main.tf
@@ -108,9 +108,6 @@ resource "null_resource" "commercetools" {
     {% if commercetools.Taxes -%}
     commercetools_tax_category.standard,
     {%- endif %}
-    {%- for store in commercetools.Stores %}
-    commercetools_store.{{ store.Key }},
-    {%- endfor -%}
   ]
 }
 


### PR DESCRIPTION
There actually was a bug in the 1.x version where for the `null_resource.commercetools` the dependencies were generated using;

```jinja
{% for store in stores %}
  commercetools_store.{{ store.key }},
{% endfor %}
```

where `stores` was never populated.

In the 2.x, managed stores are not implemented yet, but the `depends_on` where 'correctly' rendered (as in; all stores where listed) but would always error out because those resources didn't exist.

**Please note** that managed stores have to be re-implemented still, but at least this change will make sure behaviour stays the same with 1.x and fixes issues when using MACH composer with configurations where commercetools are defined (but not managed by MACH composer).