### PR TITLE
 Load configuration from single file

### DIFF
--- a/cmd/mach-composer/components.go
+++ b/cmd/mach-composer/components.go
@@ -13,28 +13,21 @@ var componentsCmd = &cobra.Command{
 		preprocessGenerateFlags()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := componentsFunc(args); err != nil {
-			return err
+		cfg := LoadConfig()
+		generateFlags.ValidateSite(cfg)
+
+		fmt.Printf("%s:\n", generateFlags.configFile)
+		for _, component := range cfg.Components {
+			fmt.Printf(" - %s\n", component.Name)
+			fmt.Printf("   version: %s\n", component.Version)
 		}
+
+		fmt.Println("")
+
 		return nil
 	},
 }
 
 func init() {
 	registerGenerateFlags(componentsCmd)
-}
-
-func componentsFunc(args []string) error {
-	cfg := LoadConfig()
-	generateFlags.ValidateSite(cfg)
-
-	fmt.Printf("%s:\n", generateFlags.configFile)
-	for _, component := range cfg.Components {
-		fmt.Printf(" - %s\n", component.Name)
-		fmt.Printf("   version: %s\n", component.Version)
-	}
-
-	fmt.Println("")
-
-	return nil
 }

--- a/cmd/mach-composer/components.go
+++ b/cmd/mach-composer/components.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var componentsCmd = &cobra.Command{
+	Use:   "components",
+	Short: "List all components.",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		preprocessGenerateFlags()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := componentsFunc(args); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	registerGenerateFlags(componentsCmd)
+}
+
+func componentsFunc(args []string) error {
+	cfg := LoadConfig()
+	generateFlags.ValidateSite(cfg)
+
+	fmt.Printf("%s:\n", generateFlags.configFile)
+	for _, component := range cfg.Components {
+		fmt.Printf(" - %s\n", component.Name)
+		fmt.Printf("   version: %s\n", component.Version)
+	}
+
+	fmt.Println("")
+
+	return nil
+}

--- a/cmd/mach-composer/generate.go
+++ b/cmd/mach-composer/generate.go
@@ -24,19 +24,18 @@ func init() {
 }
 
 func generateFunc(args []string) error {
+	cfg := LoadConfig()
+	generateFlags.ValidateSite(cfg)
+
 	genOptions := &generator.GenerateOptions{
 		OutputPath: generateFlags.outputPath,
 		Site:       generateFlags.siteName,
 	}
 
-	configs := LoadConfigs()
-	for _, filename := range generateFlags.fileNames {
-		cfg := configs[filename]
-
-		_, err := generator.WriteFiles(cfg, genOptions)
-		if err != nil {
-			panic(err)
-		}
+	_, err := generator.WriteFiles(cfg, genOptions)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }

--- a/cmd/mach-composer/main.go
+++ b/cmd/mach-composer/main.go
@@ -42,6 +42,7 @@ func init() {
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(planCmd)
+	rootCmd.AddCommand(sitesCmd)
 	rootCmd.AddCommand(updateCmd)
 	rootCmd.AddCommand(terraformCmd)
 	rootCmd.AddCommand(versionCmd)

--- a/cmd/mach-composer/main.go
+++ b/cmd/mach-composer/main.go
@@ -39,6 +39,7 @@ func main() {
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "", false, "Verbose output.")
 	rootCmd.AddCommand(applyCmd)
+	rootCmd.AddCommand(componentsCmd)
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(planCmd)

--- a/cmd/mach-composer/sites.go
+++ b/cmd/mach-composer/sites.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var sitesCmd = &cobra.Command{
+	Use:   "sites",
+	Short: "List all sites.",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		preprocessGenerateFlags()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := sitesFunc(args); err != nil {
+			return err
+		}
+		return nil
+	},
+}
+
+func init() {
+	registerGenerateFlags(sitesCmd)
+}
+
+func sitesFunc(args []string) error {
+	cfg := LoadConfig()
+	generateFlags.ValidateSite(cfg)
+
+	fmt.Printf("%s:\n", generateFlags.configFile)
+	for _, site := range cfg.Sites {
+		fmt.Printf(" - %s\n", site.Identifier)
+		fmt.Println("   components:")
+		for _, component := range site.Components {
+			fmt.Printf("     %s\n", component.Name)
+		}
+	}
+
+	fmt.Println("")
+
+	return nil
+}

--- a/cmd/mach-composer/sites.go
+++ b/cmd/mach-composer/sites.go
@@ -13,31 +13,24 @@ var sitesCmd = &cobra.Command{
 		preprocessGenerateFlags()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := sitesFunc(args); err != nil {
-			return err
+		cfg := LoadConfig()
+		generateFlags.ValidateSite(cfg)
+
+		fmt.Printf("%s:\n", generateFlags.configFile)
+		for _, site := range cfg.Sites {
+			fmt.Printf(" - %s\n", site.Identifier)
+			fmt.Println("   components:")
+			for _, component := range site.Components {
+				fmt.Printf("     %s\n", component.Name)
+			}
 		}
+
+		fmt.Println("")
+
 		return nil
 	},
 }
 
 func init() {
 	registerGenerateFlags(sitesCmd)
-}
-
-func sitesFunc(args []string) error {
-	cfg := LoadConfig()
-	generateFlags.ValidateSite(cfg)
-
-	fmt.Printf("%s:\n", generateFlags.configFile)
-	for _, site := range cfg.Sites {
-		fmt.Printf(" - %s\n", site.Identifier)
-		fmt.Println("   components:")
-		for _, component := range site.Components {
-			fmt.Printf("     %s\n", component.Name)
-		}
-	}
-
-	fmt.Println("")
-
-	return nil
 }

--- a/cmd/mach-composer/terraform.go
+++ b/cmd/mach-composer/terraform.go
@@ -30,27 +30,15 @@ func init() {
 }
 
 func terraformFunc(args []string) error {
-	allPaths := make(map[string]map[string]string)
-	configs := LoadConfigs()
+	cfg := LoadConfig()
+	generateFlags.ValidateSite(cfg)
 
-	generateFlags.ValidateSite(configs)
-
-	// Write the generate files for each config
-	genOptions := &generator.GenerateOptions{
+	fileLocations := generator.FileLocations(cfg, &generator.GenerateOptions{
 		OutputPath: generateFlags.outputPath,
 		Site:       generateFlags.siteName,
-	}
+	})
 
-	for _, filename := range generateFlags.fileNames {
-		cfg := configs[filename]
-		allPaths[filename] = generator.FileLocations(cfg, genOptions)
-	}
-
-	for _, filename := range generateFlags.fileNames {
-		cfg := configs[filename]
-		paths := allPaths[filename]
-		runner.TerraformProxy(cfg, paths, generateFlags.siteName, args)
-	}
+	runner.TerraformProxy(cfg, fileLocations, generateFlags.siteName, args)
 
 	return nil
 }


### PR DESCRIPTION
- Replaces `LoadConfigs()` with the newly added `LoadConfig()` under `cmd/`.

Also based on this change:
- Re-add support for `sites` command
- Re-add support for `components` command

Closes #177 
Closes #178 
Closes #179 
