### PR TITLE
Automatically detect the component version when registering a new version

### DIFF
--- a/cmd/mach-composer/cloudcmd/api_client.go
+++ b/cmd/mach-composer/cloudcmd/api_client.go
@@ -27,16 +27,23 @@ var listApiClientCmd = &cobra.Command{
 
 		data := make([][]string, len(paginator.Results))
 		for i, record := range paginator.Results {
+			lastUsed := "never"
+			if record.LastUsedAt != nil {
+				lastUsed = record.GetLastUsedAt().Format("2006-01-02 15:04:05")
+			}
+
 			data[i] = []string{
 				record.CreatedAt.Local().Format("2006-01-02 15:04:05"),
 				record.ClientId,
 				record.ClientSecret,
+				lastUsed,
+				record.GetDescription(),
 				strings.Join(record.Scope, " "),
 			}
 		}
 
 		writeTable(os.Stdout,
-			[]string{"Created At", "Client ID", "Client Secret", "Scopes"},
+			[]string{"Created At", "Client ID", "Client Secret", "Last Used", "Description", "Scopes"},
 			data,
 		)
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/labd/mach-composer
 
 go 1.19
 
+// replace github.com/mach-composer/mcc-sdk-go => ../mach-composer-cloud/mcc-go-sdk
+
 require (
 	github.com/creasty/defaults v1.6.0
 	github.com/davecgh/go-spew v1.1.1
@@ -11,7 +13,7 @@ require (
 	github.com/gosimple/unidecode v1.0.1
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/lithammer/dedent v1.1.0
-	github.com/mach-composer/mcc-sdk-go v0.0.1
+	github.com/mach-composer/mcc-sdk-go v0.0.2
 	github.com/mattn/go-isatty v0.0.14
 	github.com/sirupsen/logrus v1.8.1
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
@@ -50,6 +52,7 @@ require (
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 // indirect
+	golang.org/x/exp v0.0.0-20220321173239-a90fa8a75705 // indirect
 	golang.org/x/net v0.1.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
@@ -62,6 +65,7 @@ require (
 	github.com/adrg/xdg v0.4.0
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/elliotchance/pie/v2 v2.1.0
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/grokify/go-pkce v0.2.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/creasty/defaults v1.6.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbD
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/elliotchance/pie/v2 v2.1.0 h1:KEVAAzxYxTyFs4hvebFZVzBdEo3YeMzl2HYDWn+P3F4=
+github.com/elliotchance/pie/v2 v2.1.0/go.mod h1:18t0dgGFH006g4eVdDtWfgFZPQEgl10IoEO8YWEq3Og=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -197,6 +199,8 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
+github.com/mach-composer/mcc-sdk-go v0.0.2 h1:9DCKxu0a+6uY2d+MMWXZSBmz72n43N5xD7eN+JLNltI=
+github.com/mach-composer/mcc-sdk-go v0.0.2/go.mod h1:rE23R5N7WysVWT3UVt4W5ZBfMyaRkgsoRP3zTLrrCjI=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
@@ -307,6 +311,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220321173239-a90fa8a75705 h1:ba9YlqfDGTTQ5aZ2fwOoQ1hf32QySyQkR6ODGDzHlnE=
+golang.org/x/exp v0.0.0-20220321173239-a90fa8a75705/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/cloud/version.go
+++ b/internal/cloud/version.go
@@ -1,0 +1,90 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/elliotchance/pie/v2"
+	"github.com/mach-composer/mcc-sdk-go/mccsdk"
+
+	"github.com/labd/mach-composer/internal/updater"
+)
+
+func AutoRegisterVersion(ctx context.Context, client *mccsdk.APIClient, organization, project, componentKey string) (string, error) {
+	branch, err := updater.GetCurrentBranch(ctx, ".")
+	if err != nil {
+		return "", err
+	}
+
+	lastVersion, _, err := client.
+		ComponentsApi.
+		ComponentLatestVersion(ctx, organization, project, componentKey).
+		Branch(branch).
+		Execute()
+	if err != nil {
+		return "", err
+	}
+
+	baseRef := ""
+	if lastVersion != nil {
+		baseRef = lastVersion.Version
+	}
+
+	commits, err := updater.GetRecentCommits(ctx, ".", branch, baseRef)
+	if err != nil {
+		panic(err)
+	}
+
+	if len(commits) == 0 {
+		fmt.Printf("no new commits found since last version (%s)\n", baseRef)
+		return "'", nil
+	}
+
+	// Register new version
+	newVersion, _, err := client.
+		ComponentsApi.
+		ComponentVersionCreate(ctx, organization, project, componentKey).
+		ComponentVersionDraft(mccsdk.ComponentVersionDraft{
+			Version: commits[0].Commit,
+			Branch:  branch,
+		}).
+		Execute()
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("Created new version: %s (branch=%s)\n", newVersion.Version, branch)
+
+	// Push commits
+	newCommits := make([]mccsdk.CommitData, len(commits))
+	for i := range pie.Reverse(commits) {
+		c := commits[i]
+		newCommits[i] = mccsdk.CommitData{
+			Commit:  c.Commit,
+			Subject: c.Message,
+			Parents: c.Parents,
+			Author: mccsdk.CommitDataAuthor{
+				Name:  c.Author.Name,
+				Email: c.Author.Email,
+				Date:  c.Author.Date,
+			},
+			Committer: mccsdk.CommitDataAuthor{
+				Name:  c.Committer.Name,
+				Email: c.Committer.Email,
+				Date:  c.Committer.Date,
+			},
+		}
+	}
+
+	_, err = client.
+		ComponentsApi.
+		ComponentVersionPushCommits(ctx, organization, project, componentKey, newVersion.Version).
+		ComponentVersionCommits(mccsdk.ComponentVersionCommits{
+			Commits: newCommits,
+		}).
+		Execute()
+	if err != nil {
+		return newVersion.Version, err
+	}
+	fmt.Printf("Recorded %d commits for version: %s\n", len(newCommits), newVersion.Version)
+	return newVersion.Version, nil
+}


### PR DESCRIPTION
Add option to automatically detect the component version when registering a new version. It retrieves the current version from mcc and pushes commit metadata of the commits between the old and new version