### PR TITLE
Copy the variable files to the generate output

### DIFF
--- a/internal/config/types_config.go
+++ b/internal/config/types_config.go
@@ -13,8 +13,16 @@ type MachConfig struct {
 	Sites        []Site       `yaml:"sites"`
 	Components   []Component  `yaml:"components"`
 
+	ExtraFiles map[string][]byte
+
 	Variables   *Variables
 	IsEncrypted bool
+}
+
+func NewMachConfig() *MachConfig {
+	cfg := &MachConfig{}
+	cfg.ExtraFiles = make(map[string][]byte, 0)
+	return cfg
 }
 
 func (c *MachConfig) HasSite(ident string) bool {

--- a/internal/generator/writer.go
+++ b/internal/generator/writer.go
@@ -10,8 +10,9 @@ import (
 
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/labd/mach-composer/internal/config"
 	"github.com/sirupsen/logrus"
+
+	"github.com/labd/mach-composer/internal/config"
 )
 
 type GenerateOptions struct {
@@ -66,6 +67,14 @@ func WriteFiles(cfg *config.MachConfig, options *GenerateOptions) (map[string]st
 
 		if err := os.WriteFile(filename, formatted, 0700); err != nil {
 			panic(err)
+		}
+		// Write extra files
+		for extraFilename, content := range cfg.ExtraFiles {
+			extraFilename = filepath.Join(path, extraFilename)
+			fmt.Printf("Copying %s\n", extraFilename)
+			if err := os.WriteFile(extraFilename, content, 0700); err != nil {
+				return nil, fmt.Errorf("error writing extra file: %w", err)
+			}
 		}
 	}
 	return locations, nil


### PR DESCRIPTION
When a variable file is encrypted with sops we need to copy the file to the generated output so that file can be read by the sops terraform provider.