### PR TITLE
Allow carlpett/sops to be included to required providers

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -158,6 +158,7 @@ type Component struct {
 
 type TerraformConfig struct {
 	Providers   map[string]string `yaml:"providers"`
+	IncludeSops bool `yaml:"include_sops"`
 	RemoteState map[string]string `yaml:"remote_state"`
 }
 

--- a/internal/generator/generate.go
+++ b/internal/generator/generate.go
@@ -75,6 +75,11 @@ func renderTerraformConfig(cfg *config.MachConfig, site *config.SiteConfig) (str
 		}
 	}
 
+	includeSops := false
+	if cfg.Global.TerraformConfig.IncludeSops{
+		includeSops = cfg.Global.TerraformConfig.IncludeSops
+	}
+
 	template := `
 		terraform {
 			{{ .BackendConfig }}
@@ -100,7 +105,7 @@ func renderTerraformConfig(cfg *config.MachConfig, site *config.SiteConfig) (str
 	}{
 		Providers:     providers,
 		BackendConfig: backendConfig,
-		IncludeSOPS:   cfg.Variables.HasEncrypted(site.Identifier),
+		IncludeSOPS:   cfg.Variables.HasEncrypted(site.Identifier) || includeSops,
 	}
 	return renderGoTemplate(template, templateContext)
 }


### PR DESCRIPTION
Allow sops to be included to the required providers by setting include_sops to true in terraform config