### PR TITLE
Add `—cloud` option to `mach-composer update`

### DIFF
--- a/cmd/mach-composer/cloudcmd/component.go
+++ b/cmd/mach-composer/cloudcmd/component.go
@@ -168,7 +168,7 @@ var componentListVersionCmd = &cobra.Command{
 
 var componentDescribeVersionCmd = &cobra.Command{
 	Use:   "describe-component-versions [name] [version]",
-	Short: "List all version for an existing component",
+	Short: "List all changes for an component version",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()

--- a/cmd/mach-composer/cloudcmd/organization.go
+++ b/cmd/mach-composer/cloudcmd/organization.go
@@ -22,7 +22,7 @@ var listOrganizationCmd = &cobra.Command{
 		}
 
 		paginator, _, err := (client.
-			AccountManagementApi.
+			OrganizationManagementApi.
 			OrganizationQuery(ctx).
 			Execute())
 		if err != nil {
@@ -58,7 +58,7 @@ var createOrganizationCmd = &cobra.Command{
 		}
 
 		resource, _, err := (client.
-			AccountManagementApi.
+			OrganizationManagementApi.
 			OrganizationCreate(ctx).
 			OrganizationDraft(organizationDraft).
 			Execute())
@@ -84,7 +84,7 @@ var listOrganizationUsersCmd = &cobra.Command{
 		}
 
 		paginator, _, err := (client.
-			AccountManagementApi.
+			OrganizationManagementApi.
 			OrganizationUserQuery(ctx, organization).
 			Execute())
 		if err != nil {
@@ -127,7 +127,7 @@ var addOrganizationUsersCmd = &cobra.Command{
 		}
 
 		_, _, err = (client.
-			AccountManagementApi.
+			OrganizationManagementApi.
 			OrganizationUserInvite(ctx, organization).
 			OrganizationUserInviteDraft(mccsdk.OrganizationUserInviteDraft{
 				Email: email,

--- a/cmd/mach-composer/cloudcmd/project.go
+++ b/cmd/mach-composer/cloudcmd/project.go
@@ -21,7 +21,7 @@ var listProjectCmd = &cobra.Command{
 			return err
 		}
 		paginator, _, err := (client.
-			AccountManagementApi.
+			OrganizationManagementApi.
 			ProjectQuery(ctx, organization).
 			Execute())
 		if err != nil {
@@ -57,7 +57,7 @@ var createProjectCmd = &cobra.Command{
 		}
 
 		resource, _, err := (client.
-			AccountManagementApi.
+			OrganizationManagementApi.
 			ProjectCreate(ctx, organization).
 			ProjectDraft(mccsdk.ProjectDraft{
 				Name: name,

--- a/cmd/mach-composer/main.go
+++ b/cmd/mach-composer/main.go
@@ -38,7 +38,8 @@ var (
 			logger = logger.Output(cli.NewConsoleWriter())
 			log.Logger = logger
 
-			ctx, cancel := context.WithCancel(cmd.Context())
+			ctx := logger.WithContext(cmd.Context())
+			ctx, cancel := context.WithCancel(ctx)
 
 			// Register a signal handler to cancel the current context
 			c := make(chan os.Signal, 1)

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mach-composer/mach-composer-plugin-contentful v0.1.0
 	github.com/mach-composer/mach-composer-plugin-sdk v0.0.6
 	github.com/mach-composer/mach-composer-plugin-sentry v0.1.2
-	github.com/mach-composer/mcc-sdk-go v0.0.3-0.20230202151625-0e49f562e6c4
+	github.com/mach-composer/mcc-sdk-go v0.0.3-0.20230301072130-d1c0f6c7e0f0
 	github.com/mattn/go-isatty v0.0.17
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/rs/zerolog v1.29.0

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,8 @@ github.com/mach-composer/mach-composer-plugin-sentry v0.1.2 h1:58IjdfNTrpbCaTJEi
 github.com/mach-composer/mach-composer-plugin-sentry v0.1.2/go.mod h1:pvt4wqNSCM/2mUNw6Ih1lrjAx/yO3kSPbWGuBaCyf2c=
 github.com/mach-composer/mcc-sdk-go v0.0.3-0.20230202151625-0e49f562e6c4 h1:9CGcw2o/GHxw+J6dp9LvNcersTk1qgCQ9aGR4fQQjnQ=
 github.com/mach-composer/mcc-sdk-go v0.0.3-0.20230202151625-0e49f562e6c4/go.mod h1:rE23R5N7WysVWT3UVt4W5ZBfMyaRkgsoRP3zTLrrCjI=
+github.com/mach-composer/mcc-sdk-go v0.0.3-0.20230301072130-d1c0f6c7e0f0 h1:j50lfg7zohGqwAuQGi7UEsiAL+5fjTkLC+nOZ7lZPJI=
+github.com/mach-composer/mcc-sdk-go v0.0.3-0.20230301072130-d1c0f6c7e0f0/go.mod h1:rE23R5N7WysVWT3UVt4W5ZBfMyaRkgsoRP3zTLrrCjI=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=

--- a/internal/cloud/version.go
+++ b/internal/cloud/version.go
@@ -7,11 +7,11 @@ import (
 	"github.com/elliotchance/pie/v2"
 	"github.com/mach-composer/mcc-sdk-go/mccsdk"
 
-	"github.com/labd/mach-composer/internal/updater"
+	"github.com/labd/mach-composer/internal/gitutils"
 )
 
 func AutoRegisterVersion(ctx context.Context, client *mccsdk.APIClient, organization, project, componentKey string) (string, error) {
-	branch, err := updater.GetCurrentBranch(ctx, ".")
+	branch, err := gitutils.GetCurrentBranch(ctx, ".")
 	if err != nil {
 		return "", err
 	}
@@ -30,7 +30,7 @@ func AutoRegisterVersion(ctx context.Context, client *mccsdk.APIClient, organiza
 		baseRef = lastVersion.Version
 	}
 
-	commits, err := updater.GetRecentCommits(ctx, ".", branch, baseRef)
+	commits, err := gitutils.GetRecentCommits(ctx, ".", branch, baseRef)
 	if err != nil {
 		return "", err
 	}

--- a/internal/config/schemas/schema-1.yaml
+++ b/internal/config/schemas/schema-1.yaml
@@ -38,6 +38,8 @@ definitions:
           - number
       variables_file:
         type: string
+      cloud:
+        $ref: "#/definitions/MachComposerCloud"
       plugins:
         type: object
         additionalProperties: false
@@ -51,6 +53,16 @@ definitions:
               version:
                 type: string
 
+  MachComposerCloud:
+    type: object
+    required:
+      - organization
+      - project
+    properties:
+      organization:
+        type: string
+      project:
+        type: string
 
   GlobalConfig:
     type: object

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -116,6 +116,22 @@ type MachComposer struct {
 	Version       any                         `yaml:"version"`
 	VariablesFile string                      `yaml:"variables_file"`
 	Plugins       map[string]MachPluginConfig `yaml:"plugins"`
+	Cloud         MachComposerCloud           `yaml:"cloud"`
+}
+
+type MachComposerCloud struct {
+	Organization string `yaml:"organization"`
+	Project      string `yaml:"project"`
+}
+
+func (mcc *MachComposerCloud) Empty() bool {
+	if mcc.Organization == "" {
+		return true
+	}
+	if mcc.Project == "" {
+		return true
+	}
+	return false
 }
 
 type MachPluginConfig struct {

--- a/internal/gitutils/git.go
+++ b/internal/gitutils/git.go
@@ -1,4 +1,4 @@
-package updater
+package gitutils
 
 import (
 	"context"
@@ -43,7 +43,7 @@ type gitCommitAuthor struct {
 	Date  time.Time
 }
 
-func GetLastVersionGit(ctx context.Context, c *config.Component, origin string) (*ChangeSet, error) {
+func GetLastVersionGit(ctx context.Context, c *config.Component, origin string) ([]gitCommit, error) {
 	cacheDir, err := getGitCachePath(origin)
 	if err != nil {
 		return nil, err
@@ -65,18 +65,8 @@ func GetLastVersionGit(ctx context.Context, c *config.Component, origin string) 
 		return nil, err
 	}
 
-	cs := &ChangeSet{
-		Changes:   commits,
-		Component: c,
-	}
+	return commits, nil
 
-	if len(commits) < 1 {
-		cs.LastVersion = c.Version
-	} else {
-		cs.LastVersion = commits[0].Commit
-	}
-
-	return cs, nil
 }
 
 func getGitCachePath(origin string) (string, error) {

--- a/internal/gitutils/git_test.go
+++ b/internal/gitutils/git_test.go
@@ -1,4 +1,4 @@
-package updater
+package gitutils
 
 import (
 	"testing"

--- a/internal/runner/apply.go
+++ b/internal/runner/apply.go
@@ -77,6 +77,7 @@ func TerraformApplySite(ctx context.Context, cfg *config.MachConfig, site *confi
 	}
 	if planFilename != "" {
 		cmd = append(cmd, planFilename)
+		cmd = append(cmd, "-lockfile=readonly")
 	}
 
 	return RunTerraform(ctx, path, cmd...)

--- a/internal/updater/changes.go
+++ b/internal/updater/changes.go
@@ -3,6 +3,7 @@ package updater
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/labd/mach-composer/internal/config"
 )
@@ -14,9 +15,23 @@ type UpdateSet struct {
 
 type ChangeSet struct {
 	LastVersion string
-	Changes     []gitCommit
+	Changes     []CommitData
 	Component   *config.Component
 	Forced      bool
+}
+
+type CommitData struct {
+	Commit    string
+	Parents   []string
+	Author    CommitAuthor
+	Committer CommitAuthor
+	Message   string
+}
+
+type CommitAuthor struct {
+	Name  string
+	Email string
+	Date  time.Time
 }
 
 func (cs *ChangeSet) HasChanges() bool {

--- a/internal/updater/updates.go
+++ b/internal/updater/updates.go
@@ -1,0 +1,247 @@
+package updater
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/rs/zerolog"
+
+	"github.com/labd/mach-composer/internal/config"
+	"github.com/labd/mach-composer/internal/gitutils"
+)
+
+func findUpdates(ctx context.Context, cfg *PartialConfig, filename string) (*UpdateSet, error) {
+	zerolog.Ctx(ctx).Info().Msgf("Checking if there are updates for %d components\n", len(cfg.Components))
+	if cfg.client == nil {
+		return findUpdatesParallel(ctx, cfg, filename)
+	}
+	return findUpdatesSerial(ctx, cfg, filename)
+}
+
+func findUpdatesSerial(ctx context.Context, cfg *PartialConfig, filename string) (*UpdateSet, error) {
+	updates := UpdateSet{
+		filename: filename,
+	}
+
+	for i := range cfg.Components {
+		cs, err := getLastVersion(ctx, cfg, &cfg.Components[i], cfg.filename)
+		if err != nil {
+			return nil, err
+		}
+
+		if cs == nil {
+			continue
+		}
+
+		output := OutputChanges(cs)
+		zerolog.Ctx(ctx).Info().Msg(output)
+
+		if cs.HasChanges() {
+			updates.updates = append(updates.updates, *cs)
+		}
+	}
+	return &updates, nil
+}
+
+func findUpdatesParallel(ctx context.Context, cfg *PartialConfig, filename string) (*UpdateSet, error) {
+	numUpdates := len(cfg.Components)
+	jobs := make(chan WorkerJob, numUpdates)
+	results := make(chan *ChangeSet, numUpdates)
+	errors := make(chan error, numUpdates)
+
+	var wg sync.WaitGroup
+	const numWorkers = 4
+
+	// Start 4 workers
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for j := range jobs {
+				cs, err := getLastVersion(ctx, cfg, j.component, j.cfg.filename)
+				if err != nil {
+					errors <- err
+					return
+				}
+
+				if cs == nil {
+					continue
+				}
+
+				results <- cs
+			}
+		}()
+	}
+
+	// Send work
+	for i := range cfg.Components {
+		jobs <- WorkerJob{
+			component: &cfg.Components[i],
+			cfg:       cfg,
+		}
+	}
+	close(jobs)
+
+	wg.Wait()
+	close(errors)
+
+	for err := range errors {
+		return nil, err
+	}
+
+	// Process results as we receive them from the channel
+	updates := UpdateSet{
+		filename: filename,
+	}
+	for i := 0; i < numUpdates; i++ {
+		changeSet := <-results
+
+		if changeSet == nil {
+			continue
+		}
+
+		output := OutputChanges(changeSet)
+		zerolog.Ctx(ctx).Info().Msg(output)
+
+		if changeSet.HasChanges() {
+			updates.updates = append(updates.updates, *changeSet)
+		}
+	}
+
+	return &updates, nil
+}
+
+func findSpecificUpdate(ctx context.Context, cfg *PartialConfig, filename string, component *config.Component) (*UpdateSet, error) {
+	changeSet, err := getLastVersion(ctx, cfg, component, cfg.filename)
+	if err != nil {
+		return nil, err
+	}
+
+	output := OutputChanges(changeSet)
+	zerolog.Ctx(ctx).Info().Msg(output)
+
+	updates := UpdateSet{
+		filename: cfg.filename,
+		updates:  []ChangeSet{*changeSet},
+	}
+	return &updates, nil
+}
+
+func getLastVersion(ctx context.Context, cfg *PartialConfig, c *config.Component, origin string) (*ChangeSet, error) {
+	if cfg.client != nil {
+		return getLastVersionCloud(ctx, cfg, c, origin)
+	}
+
+	if strings.HasPrefix(c.Source, "git:") {
+		return getLastVersionGit(ctx, cfg, c, origin)
+	}
+
+	err := &UpdateError{
+		msg:       fmt.Sprintf("unrecognized component source for %s: %s", c.Name, c.Source),
+		component: c.Name,
+		source:    c.Source,
+	}
+	return nil, err
+}
+
+func getLastVersionCloud(ctx context.Context, cfg *PartialConfig, c *config.Component, origin string) (*ChangeSet, error) {
+	organization := cfg.MachComposer.Cloud.Organization
+	project := cfg.MachComposer.Cloud.Project
+
+	version, _, err := cfg.client.
+		ComponentsApi.ComponentLatestVersion(ctx, organization, project, c.Name).
+		Branch(c.Branch).
+		Execute()
+
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msgf("Error checking for latest version of %s", c.Name)
+		return nil, nil
+	}
+
+	if version == nil {
+		zerolog.Ctx(ctx).Warn().Msgf("No version found for %s", c.Name)
+		return nil, nil
+	}
+
+	cs := &ChangeSet{
+		Changes:     []CommitData{},
+		Component:   c,
+		LastVersion: version.Version,
+	}
+
+	if c.Version != version.Version {
+		paginator, _, err := cfg.client.
+			ComponentsApi.
+			ComponentVersionQueryCommits(ctx, organization, project, c.Name, version.Version).
+			Offset(0).
+			Limit(200).
+			Execute()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, record := range paginator.Results {
+			change := CommitData{
+				Commit:  record.Commit,
+				Parents: record.Parents,
+				Message: record.Subject,
+				Author: CommitAuthor{
+					Email: record.Author.Email,
+					Name:  record.Author.Name,
+					Date:  record.Author.Date,
+				},
+				Committer: CommitAuthor{
+					Email: record.Committer.Email,
+					Name:  record.Committer.Name,
+					Date:  record.Committer.Date,
+				},
+			}
+			cs.Changes = append(cs.Changes, change)
+		}
+	}
+
+	return cs, nil
+}
+
+func getLastVersionGit(ctx context.Context, cfg *PartialConfig, c *config.Component, origin string) (*ChangeSet, error) {
+	commits, err := gitutils.GetLastVersionGit(ctx, c, origin)
+	if err != nil {
+		return nil, err
+	}
+
+	cd := make([]CommitData, len(commits))
+	for i := range commits {
+		c := commits[i]
+
+		cd[i].Commit = c.Commit
+		cd[i].Parents = c.Parents
+		cd[i].Message = c.Message
+
+		cd[i].Author = CommitAuthor{
+			Email: c.Author.Email,
+			Name:  c.Author.Name,
+			Date:  c.Author.Date,
+		}
+		cd[i].Committer = CommitAuthor{
+			Email: c.Committer.Email,
+			Name:  c.Committer.Name,
+			Date:  c.Committer.Date,
+		}
+	}
+
+	cs := &ChangeSet{
+		Changes:   cd,
+		Component: c,
+	}
+
+	if len(commits) < 1 {
+		cs.LastVersion = c.Version
+	} else {
+		cs.LastVersion = commits[0].Commit
+	}
+
+	return cs, nil
+}


### PR DESCRIPTION
This options uses mach composer cloud to fetch the latest component versions instead of relying on the git repositories.
