### PR TITLE
Add extra arguments to the `cloud register-component-version` cmd

### DIFF
--- a/.changes/unreleased/Added-20230314-170347.yaml
+++ b/.changes/unreleased/Added-20230314-170347.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Add `--dry-run` and `--git-filter-paths` to `cloud register-component-version`
+  command. The `--git-filter-paths` argument can be used to limit the scope of the
+  changes when working within monorepo's
+time: 2023-03-14T17:03:47.816564+01:00

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,9 @@ require (
 	github.com/adrg/xdg v0.4.0
 	github.com/elliotchance/pie/v2 v2.5.1
 	github.com/fatih/color v1.14.1
+	github.com/go-git/go-billy/v5 v5.4.1
 	github.com/go-git/go-git/v5 v5.6.0
+	github.com/google/uuid v1.3.0
 	github.com/grokify/go-pkce v0.2.0
 	github.com/hashicorp/go-getter v1.7.0
 	github.com/hashicorp/go-hclog v1.4.0
@@ -57,11 +59,9 @@ require (
 	github.com/flosch/pongo2/v5 v5.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
-	github.com/go-git/go-billy/v5 v5.4.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect

--- a/internal/gitutils/git.go
+++ b/internal/gitutils/git.go
@@ -183,6 +183,7 @@ func GetCurrentBranch(ctx context.Context, path string) (string, error) {
 }
 
 // GetRecentCommits returns all commits in descending order (newest first)
+// baseRef is the commit to start from, if empty the current HEAD is used
 func GetRecentCommits(ctx context.Context, basePath string, branch string, baseRef string, extraPaths []string) ([]gitCommit, error) {
 	gitPath, err := getGitPath(basePath)
 	if err != nil {
@@ -209,6 +210,7 @@ func GetRecentCommits(ctx context.Context, basePath string, branch string, baseR
 		}
 	}
 
+	// Resolve the last comit in the branch
 	var branchRevision *plumbing.Hash
 	if branch == "" {
 		branchRef, err := repository.Head()
@@ -281,7 +283,7 @@ func relativePaths(gitPath string, paths []string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, rel)
+		result = append(result, fmt.Sprintf("%s%s", rel, string(filepath.Separator)))
 	}
 	return result, nil
 }

--- a/internal/gitutils/git_test.go
+++ b/internal/gitutils/git_test.go
@@ -2,8 +2,14 @@ package gitutils
 
 import (
 	"testing"
+	"time"
 
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseGitSource(t *testing.T) {
@@ -35,4 +41,130 @@ func TestParseGitSource(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, p.expected, res)
 	}
+}
+
+func TestCommitsBetwee(t *testing.T) {
+	repo, err := git.Init(memory.NewStorage(), memfs.New())
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+
+	// First commit
+	err = addNewFile(worktree, "test-1.txt")
+	require.NoError(t, err)
+
+	firsthash, err := worktree.Commit("Initial commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test",
+			Email: "test@example.org",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	// Second commit
+	err = addNewFile(worktree, "test-2.txt")
+	require.NoError(t, err)
+
+	secondhash, err := worktree.Commit("Second commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test",
+			Email: "test@example.org",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	commits, err := commitsBetween(repo, nil, &secondhash, []string{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(commits))
+
+	commits, err = commitsBetween(repo, &firsthash, &secondhash, []string{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(commits))
+}
+
+func TestCommitsBetweenFilterPath(t *testing.T) {
+	repo, err := git.Init(memory.NewStorage(), memfs.New())
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+
+	// First commit
+	err = addNewFile(worktree, "test-1.txt")
+	require.NoError(t, err)
+
+	firsthash, err := worktree.Commit("Initial commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test",
+			Email: "test@example.org",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, firsthash)
+
+	// Second commit
+	err = addNewFile(worktree, "test-2.txt")
+	require.NoError(t, err)
+
+	err = addNewFile(worktree, "wanted/test-2.txt")
+	require.NoError(t, err)
+
+	_, err = worktree.Commit("Second commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test",
+			Email: "test@example.org",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	// Third commit
+	err = addNewFile(worktree, "test-3.txt")
+	require.NoError(t, err)
+
+	err = addNewFile(worktree, "wantedotherdir/test-3.txt")
+	require.NoError(t, err)
+
+	thirdhash, err := worktree.Commit("third commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test",
+			Email: "test@example.org",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	// Check results
+	commits, err := commitsBetween(repo, nil, &thirdhash, []string{})
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(commits))
+
+	commits, err = commitsBetween(repo, nil, &thirdhash, []string{"wanted/"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(commits))
+}
+
+func addNewFile(w *git.Worktree, filename string) error {
+	file, err := w.Filesystem.Create(filename)
+	if err != nil {
+		return err
+	}
+
+	text := []byte("Text file 1")
+	if _, err = file.Write(text); err != nil {
+		return err
+	}
+
+	if err := file.Close(); err != nil {
+		return err
+	}
+
+	_, err = w.Add(filename)
+	return err
 }


### PR DESCRIPTION
Add `--dry-run` and `--git-filter-paths` to `cloud register-component-version` command.  The `--git-filter-paths` argument can be used to limit the scope of the changes when working within monorepo's.