### PR TITLE
fix/improve git autoversion

### DIFF
--- a/.changes/unreleased/Fixed-20230317-125739.yaml
+++ b/.changes/unreleased/Fixed-20230317-125739.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Improve the component version registration flow
+time: 2023-03-17T12:57:39.700633+01:00

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,4 +17,3 @@ linters:
   - tenv
   - typecheck
   - unused
-  - whitespace

--- a/cmd/mach-composer/cloudcmd/component.go
+++ b/cmd/mach-composer/cloudcmd/component.go
@@ -87,7 +87,7 @@ var componentRegisterVersionCmd = &cobra.Command{
 
 		organization := MustGetString(cmd, "organization")
 		project := MustGetString(cmd, "project")
-		gitFilterPaths, err := cmd.Flags().GetStringArray("git-filter-paths")
+		gitFilterPaths, err := cmd.Flags().GetStringArray("git-filter-path")
 		if err != nil {
 			return err
 		}
@@ -132,6 +132,10 @@ var componentRegisterVersionCmd = &cobra.Command{
 				return err
 			}
 			gitFilterPaths = pie.Map(gitFilterPaths, func(path string) string {
+				if filepath.IsAbs(path) {
+					return path
+				}
+
 				return filepath.Join(cwd, path)
 			})
 			_, err = cloud.AutoRegisterVersion(ctx, client, organization, project, componentKey, dryRun, gitFilterPaths)
@@ -290,7 +294,7 @@ func init() {
 	registerContextFlags(componentRegisterVersionCmd)
 	componentRegisterVersionCmd.Flags().Bool("auto", false, "Automate")
 	componentRegisterVersionCmd.Flags().Bool("dry-run", false, "Dry run")
-	componentRegisterVersionCmd.Flags().StringArray("git-filter-paths", nil, "Filter comits based on given paths")
+	componentRegisterVersionCmd.Flags().StringArray("git-filter-path", nil, "Filter comits based on given paths")
 
 	CloudCmd.AddCommand(componentListVersionCmd)
 	registerContextFlags(componentListVersionCmd)


### PR DESCRIPTION
This PR improves the way the commits between the last version and the current version are calculated. It improves the --git-filter-path implementation