### PR TITLE
Fix mach-composer update for $ref files

### DIFF
--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -94,7 +94,7 @@ func loadConfig(ctx context.Context, filename string, pr *plugins.PluginReposito
 		return nil, err
 	}
 
-	if err := loadRefData(ctx, &raw.Components, path.Dir(filename)); err != nil {
+	if _, err := LoadRefData(ctx, &raw.Components, path.Dir(filename)); err != nil {
 		return nil, err
 	}
 

--- a/internal/config/parse_test.go
+++ b/internal/config/parse_test.go
@@ -353,7 +353,7 @@ func TestParseComponentsNodeRef(t *testing.T) {
 	err = yaml.Unmarshal(data, &intermediate)
 	require.NoError(t, err)
 
-	err = loadRefData(context.Background(), &intermediate.Components, "")
+	_, err = LoadRefData(context.Background(), &intermediate.Components, "")
 	require.NoError(t, err)
 
 	cfg := &MachConfig{

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -60,25 +60,25 @@ func iterateYamlNodes(
 	return nil
 }
 
-func loadRefData(ctx context.Context, node *yaml.Node, cwd string) error {
+func LoadRefData(ctx context.Context, node *yaml.Node, cwd string) (string, error) {
 	if node.Kind != yaml.MappingNode {
-		return nil
+		return "", nil
 	}
 
 	data := mapYamlNodes(node.Content)
 	ref, ok := data["$ref"]
 	if !ok {
-		return nil
+		return "", nil
 	}
 
 	newNode, err := loadRefDocument(ctx, ref.Value, cwd)
 	if err != nil {
-		return err
+		return "", err
 	}
 	node.Kind = newNode.Kind
 	node.Content = newNode.Content
 
-	return nil
+	return ref.Value, nil
 }
 
 func loadRefDocument(ctx context.Context, filename, cwd string) (*yaml.Node, error) {

--- a/internal/config/utils_test.go
+++ b/internal/config/utils_test.go
@@ -95,11 +95,12 @@ func TestMapYamlNodes(t *testing.T) {
 
 func TestLoadRefData(t *testing.T) {
 	tests := []struct {
-		name       string
-		node       *yaml.Node
-		refContent string
-		expected   *yaml.Node
-		wantErr    bool
+		name        string
+		node        *yaml.Node
+		refContent  string
+		refFilename string
+		expected    *yaml.Node
+		wantErr     bool
 	}{
 		{
 			name: "mapping node with $ref",
@@ -110,7 +111,8 @@ func TestLoadRefData(t *testing.T) {
 					{Value: "ref.yaml"},
 				},
 			},
-			refContent: "key: value",
+			refContent:  "key: value",
+			refFilename: "ref.yaml",
 			expected: &yaml.Node{
 				Kind: yaml.MappingNode,
 				Content: []*yaml.Node{
@@ -134,6 +136,7 @@ func TestLoadRefData(t *testing.T) {
 					other-node:
 						key: value
 			`),
+			refFilename: "ref.yaml#/some-node/other-node",
 			expected: &yaml.Node{
 				Kind: yaml.MappingNode,
 				Content: []*yaml.Node{
@@ -152,7 +155,8 @@ func TestLoadRefData(t *testing.T) {
 					{Value: "value"},
 				},
 			},
-			refContent: "",
+			refContent:  "",
+			refFilename: "",
 			expected: &yaml.Node{
 				Kind: yaml.MappingNode,
 				Content: []*yaml.Node{
@@ -171,9 +175,10 @@ func TestLoadRefData(t *testing.T) {
 					{Value: "other.yaml"},
 				},
 			},
-			refContent: "",
-			expected:   nil,
-			wantErr:    true,
+			refContent:  "",
+			refFilename: "other.yaml",
+			expected:    nil,
+			wantErr:     true,
 		},
 	}
 
@@ -187,10 +192,11 @@ func TestLoadRefData(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := loadRefData(context.Background(), tc.node, "./")
+			filename, err := LoadRefData(context.Background(), tc.node, "./")
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
+				assert.Equal(t, filename, tc.refFilename)
 				assert.NoError(t, err)
 
 				expectedData := []byte{}

--- a/internal/updater/writer_sops.go
+++ b/internal/updater/writer_sops.go
@@ -8,9 +8,9 @@ import (
 	"github.com/labd/mach-composer/internal/utils"
 )
 
-// SopsFileWriter updates the contents of a mach file with the updated
+// sopsFileWriter updates the contents of a mach file with the updated
 // version of the components
-func SopsFileWriter(ctx context.Context, cfg *PartialConfig, updates *UpdateSet) {
+func sopsFileWriter(ctx context.Context, cfg *PartialConfig, updates *UpdateSet) {
 	indexMap := make(map[string]int)
 
 	for i := range cfg.Components {


### PR DESCRIPTION
When the components.yaml is included via $ref syntax the mach-composer
update command didn’t work.

This commit updates the referenced file
